### PR TITLE
Update Allen key size reference in calibration guide

### DIFF
--- a/calibration/tolerance-calib.md
+++ b/calibration/tolerance-calib.md
@@ -30,7 +30,7 @@ This calibration test is designed to evaluate the dimensional accuracy of your p
 
 ![tolerance_hole](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/Tolerance/tolerance_hole.svg?raw=true)
 
-You can check the tolerance using either an M6 Allen key or the included printed hexagon tester.
+You can check the tolerance using either an 6mm Allen key or the included printed hexagon tester.
 Use calipers to measure both the holes and the inner tester. Based on your results, you can fine-tune the X-Y hole compensation and X-Y contour compensation settings. Repeat the process until you achieve the desired precision.
 
 ![OrcaToleranceTes_m6](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/Tolerance/OrcaToleranceTes_m6.jpg?raw=true)


### PR DESCRIPTION
Changed 'M6 Allen key' to '6mm Allen key' for clarity in the tolerance calibration instructions.