### PR TITLE
Update issue templates and remove file upload fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,15 +1,15 @@
 name: 🐞 Error Report
 description: File an error report
-labels: ["Error"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
         **Thank you for using OrcaSlicer and wanting to report an error.**
-        
+
         Please note that this is only for reportings errors in the OrcaSlicer Wiki.
         For issues with OrcaSlicer itself, please use the main [OrcaSlicer GitHub repository](https://github.com/OrcaSlicer/OrcaSlicer/issues).
-        
+
         Before filing, please check if the issue already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment.
   - type: checkboxes
     attributes:
@@ -34,12 +34,3 @@ body:
       placeholder: e.g. "The instructions on this page did not work as expected because..."
     validations:
       required: true
-  - type: textarea
-    id: file_uploads
-    attributes:
-      label: Attachments to improve the page.
-      description:  If you want to update some files (images, code snippets, etc.) to improve the wiki page, please attach them here.
-      placeholder: |
-        You can attach images, code snippets, or any other relevant files that would help improve the wiki page.
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -35,12 +35,3 @@ body:
         e.g. "It would be great to have a page that explains how to set up custom supports because..."
     validations:
       required: true
-  - type: textarea
-    attributes:
-      label: Additional context
-      description: |
-        Add any other context, diagrams, illustations or screenshots about the feature request here.
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-    validations:
-      required: false


### PR DESCRIPTION
# Description

Changed the label in the bug report template from 'Error' to 'bug' and removed the file upload/attachments textarea from both bug report and feature request templates to streamline issue submission.