### PR TITLE
Add example G-codes for extrusion role changes

### DIFF
--- a/printer_settings/machine gcode/printer_machine_gcode.md
+++ b/printer_settings/machine gcode/printer_machine_gcode.md
@@ -45,6 +45,25 @@ This G-code is inserted when filament is changed, including T commands to trigge
 
 This G-code is inserted when the extrusion role is changed.
 
+Example G-codes:
+
+- Marlin g-code to set fan speed to 10% (S25 out of S255) for BridgeInfill role and 30% (S75 out of S255) for other roles:
+  ```c++
+  {if( extrusion_role == "BridgeInfill")}
+  M106 S25
+  {else}
+  M106 S75
+  {endif}
+  ```
+- Marlin g-code to set pressure advance to 0 for InternalInfill role and restore it to previous value for other roles:
+  ```c++
+  {if( extrusion_role == "InternalInfill")}
+  M900 K0
+  {else}
+  M900 K{pressure_advance[0]}
+  {endif}
+  ```
+
 ## Pause G-code
 
 This G-code will be used as a code for the pause print. Users can insert pause G-code in the G-code viewer.


### PR DESCRIPTION
Provides sample Marlin G-code snippets demonstrating how to set fan speed and pressure advance based on extrusion roles. This helps users customize machine behavior for specific print scenarios.