### PR TITLE
Expand Tab link reference detection and update wiki docs

### DIFF
--- a/.github/workflows/validate_tab_links.yml
+++ b/.github/workflows/validate_tab_links.yml
@@ -42,7 +42,7 @@ jobs:
 
             const references = collectReferences(source);
             if (!references.length) {
-              core.info('No double-string append_single_option_line entries found.');
+              core.info('No Tab link references found.');
               return;
             }
 
@@ -122,10 +122,10 @@ jobs:
             core.info(`Validated ${references.length} Tab link(s). All good.`);
 
             function collectReferences(text) {
-              const pattern = /append_single_option_line\s*\(\s*"([^"]+)"\s*(?:,\s*"([^"]+)")?/g;
               const refs = [];
+              const appendSinglePattern = /append_single_option_line\s*\(\s*"([^"]+)"\s*(?:,\s*"([^"]+)")?/g;
               let match;
-              while ((match = pattern.exec(text)) !== null) {
+              while ((match = appendSinglePattern.exec(text)) !== null) {
                 if (!match[2]) {
                   continue;
                 }
@@ -135,6 +135,25 @@ jobs:
                   line: lineFromIndex(text, match.index),
                 });
               }
+
+              const labelPathPattern = /label_path\s*=\s*"([^"]+)"/g;
+              while ((match = labelPathPattern.exec(text)) !== null) {
+                refs.push({
+                  option: 'label_path',
+                  target: match[1].trim(),
+                  line: lineFromIndex(text, match.index),
+                });
+              }
+
+              const appendOptionLinePattern = /append_option_line\s*\(\s*[^,]+,\s*[^,]+,\s*"([^"]+)"/g;
+              while ((match = appendOptionLinePattern.exec(text)) !== null) {
+                refs.push({
+                  option: 'append_option_line',
+                  target: match[1].trim(),
+                  line: lineFromIndex(text, match.index),
+                });
+              }
+
               return refs;
             }
 

--- a/developer-reference/How-to-wiki.md
+++ b/developer-reference/How-to-wiki.md
@@ -88,20 +88,50 @@ When creating new pages, follow these file-naming conventions:
 
 OrcaSlicer can redirect users from the GUI to the appropriate wiki pages, making it easier to find relevant documentation.
 
-The option-to-wiki mapping is defined in [src/slic3r/GUI/Tab.cpp](https://github.com/OrcaSlicer/OrcaSlicer/blob/main/src/slic3r/GUI/Tab.cpp). Any option added with `append_single_option_line` can be mapped to a wiki page using a second string argument.
+The option-to-wiki mapping is defined in [src/slic3r/GUI/Tab.cpp](https://github.com/OrcaSlicer/OrcaSlicer/blob/main/src/slic3r/GUI/Tab.cpp).
+The links naming uses the same format as the [Wiki Navigation described above](#index-and-navigation), `[filename]#[section(optional)]` e.g. `quality_settings_seam` or `quality_settings_seam#scarf-joint-seam`.
+
+There are 3 main ways to set up these links:
+
+1. Using `append_single_option_line` with a second string argument for the wiki page.
 
 ```cpp
-optgroup->append_single_option_line("OPTION_NAME"); // Option without wiki page/redirection
-optgroup->append_single_option_line("OPTION_NAME", "WIKI_PAGE"); // Option with wiki page and redirection
+optgroup->append_single_option_line("[OPTION_NAME]"); // Option without wiki page/redirection
+optgroup->append_single_option_line("[OPTION_NAME]", "[WIKI_LINK]"); // Option with wiki page and redirection
 ```
-
-You can also point to a specific section within a wiki page by appending a fragment identifier (for example `#section-name`).
 
 Example:
 
 ```cpp
 optgroup->append_single_option_line("seam_gap","quality_settings_seam"); // Wiki page and redirection
 optgroup->append_single_option_line("seam_slope_type", "quality_settings_seam#scarf-joint-seam"); // Wiki page and redirection to `Scarf Joint Seam` section
+```
+
+2. Using `append_option_line` with a third string argument for the wiki page.
+
+```cpp
+append_option_line([optgroup], [opt_key], "[WIKI_LINK]");
+```
+
+Example:
+
+```cpp
+append_option_line(optgroup, "machine_max_acceleration_x", "printer_motion_ability#acceleration-limitation");
+```
+
+3. Using grouped rows with `append_line` and setting the wiki target via `line.label_path`.
+
+```cpp
+line.label_path = "[WIKI_LINK]";
+```
+
+Example:
+
+```cpp
+Line line = { L("Overhang speed"), L("...") };
+line.label_path = "speed_settings_overhang_speed#slow-down-for-overhang";
+line.append_option(optgroup->get_option("overhang_1_4_speed"));
+optgroup->append_line(line);
 ```
 
 ## Formatting and Style


### PR DESCRIPTION
Enhanced the GitHub workflow to detect Tab link references from label_path and append_option_line in addition to append_single_option_line. Updated the developer wiki to document all three supported methods for linking options to wiki pages, including examples and link format details.

Closes #42