### PR TITLE
Added disable value for 'Full fan speed at layer' material setting

### DIFF
--- a/material_settings/cooling/material_cooling.md
+++ b/material_settings/cooling/material_cooling.md
@@ -35,7 +35,7 @@ Turn off all cooling fans for the first few layers. This can be used to improve 
 
 ### Full fan speed at layer
 
-Fan speed will be ramped up linearly from zero at layer "close_fan_the_first_x_layers" to maximum at layer "full_fan_speed_layer". "full_fan_speed_layer" will be ignored if lower than "close_fan_the_first_x_layers", in which case the fan will be running at maximum allowed speed at layer "close_fan_the_first_x_layers" + 1.
+Fan speed will be ramped up linearly from zero at layer "close_fan_the_first_x_layers" to maximum at layer "full_fan_speed_layer". "full_fan_speed_layer" will be ignored if lower than "close_fan_the_first_x_layers", in which case the fan will be running at maximum allowed speed at layer "close_fan_the_first_x_layers" + 1. 0 to disable.
 
 ## Material Part Cooling Fan
 


### PR DESCRIPTION
0 Disables this feature, but it is not obvious. Added to the wiki.