### PR TITLE
Machine Gcode examples + Warnings

### DIFF
--- a/printer_settings/machine gcode/printer_machine_gcode.md
+++ b/printer_settings/machine gcode/printer_machine_gcode.md
@@ -100,7 +100,7 @@ This G-code is inserted when the extrusion role is changed.
 Example G-codes:
 
 - Marlin g-code to set fan speed to 10% (S25 out of S255) for BridgeInfill role and 30% (S75 out of S255) for other roles:
-  ```c++
+  ```gcode
   {if( extrusion_role == "BridgeInfill")}
   M106 S25
   {else}
@@ -108,7 +108,7 @@ Example G-codes:
   {endif}
   ```
 - Marlin g-code to set pressure advance to 0 for InternalInfill role and restore it to previous value for other roles:
-  ```c++
+  ```gcode
   {if( extrusion_role == "InternalInfill")}
   M900 K0
   {else}


### PR DESCRIPTION
- Included a detailed example demonstrating custom notifications with M300 and a purge sequence in the start G-code section.
- Added a warning highlighting the power and risks of custom machine G-code scripts. The note advises users to use known G-code bases for their firmware and to thoroughly test scripts before production use.
- Add firmware G-code documentation links