### PR TITLE
Expand labelPathPattern to match more identifiers

### DIFF
--- a/.github/workflows/validate_tab_links.yml
+++ b/.github/workflows/validate_tab_links.yml
@@ -138,7 +138,7 @@ jobs:
                 });
               }
 
-              const labelPathPattern = /\bline\s*\.\s*label_path\s*=\s*"([^"]+)"/g;
+              const labelPathPattern = /\b[A-Za-z_]\w*\s*\.\s*label_path\s*=\s*"([^"]+)"/g;
               while ((match = labelPathPattern.exec(text)) !== null) {
                 refs.push({
                   option: 'label_path',


### PR DESCRIPTION
Updated the regex in validate_tab_links.yml to match any valid identifier before '.label_path', not just 'line'. This allows the workflow to detect label_path assignments for more objects.