### PR TITLE
Add troubleshooting tip for missing 'Fix model' option in VS build

### DIFF
--- a/developer-reference/How-to-build.md
+++ b/developer-reference/How-to-build.md
@@ -56,6 +56,7 @@ How to building with Visual Studio on Windows 64-bit.
 
 > [!TIP]
 > GitHub Desktop (optional): A GUI for Git and Git LFS, which already includes both tools.
+>
 > ```shell
 > winget install --id=GitHub.GitHubDesktop -e
 > ```
@@ -84,6 +85,7 @@ How to building with Visual Studio on Windows 64-bit.
      ```shell
      git clone https://github.com/OrcaSlicer/OrcaSlicer
      ```
+
      2. Run lfs to download tools on Windows:
      ```shell
      git lfs pull
@@ -92,6 +94,7 @@ How to building with Visual Studio on Windows 64-bit.
    ```MD
    x64 Native Tools Command Prompt for VS
    ```
+
    1. Navigate to correct drive (if needed), e.g.:
       ```shell
       N:
@@ -136,20 +139,17 @@ How to building with Visual Studio on Windows 64-bit.
 > [!TIP]
 > If the "Fix model" option is missing from an object's context menu, it may indicate that your build did not properly include the Windows SDK. To quickly resolve this, follow these steps:
 >
-> 1. Locate the `winrt` folder in your Windows SDK installation. For example:  
+> 1. Locate the `winrt` folder in your Windows SDK installation. For example:
 >    ```shell
 >    C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\winrt
->    ```  
->    *(Note: the exact path may vary depending on your Windows SDK version.)*
->
+>    ```
+>    _(Note: the exact path may vary depending on your Windows SDK version.)_
 > 2. In Visual Studio 2022, open the **libslic3r_gui** project properties:  
 >    Go to **Configuration Properties > C/C++ > Preprocessor > Preprocessor Definitions**  
 >    ➕ Add: `HAS_WIN10SDK`
->
 > 3. In Visual Studio 2022, open the **OrcaSlicer_app_gui** project properties:  
 >    Go to **Configuration Properties > C/C++ > General > Additional Include Directories**  
 >    ➕ Add the path to the `winrt` folder from step 1.
->
 > 4. Build the solution.
 
 ## MacOS 64-bit
@@ -169,6 +169,7 @@ How to building with Xcode on MacOS 64-bit.
 
 > [!TIP]
 > You can install most of them by running:
+>
 > ```shell
 > brew install gettext libtool automake autoconf texinfo
 > ```
@@ -308,21 +309,25 @@ The build system supports multiple Linux distributions including Ubuntu/Debian a
 #### Linux Instructions
 
 1. **Install system dependencies:**
+
    ```shell
    ./build_linux.sh -u
    ```
 
 2. **Build dependencies:**
+
    ```shell
    ./build_linux.sh -d
    ```
 
 3. **Build OrcaSlicer with tests:**
+
    ```shell
    ./build_linux.sh -st
    ```
 
 4. **Build AppImage (optional):**
+
    ```shell
    ./build_linux.sh -i
    ```


### PR DESCRIPTION
# Description

Added a new tip to the Windows Visual Studio build instructions to help users resolve the issue where the 'Fix model' context menu option is missing. The tip explains how to ensure the Windows SDK is properly included and provides step-by-step guidance for updating project properties in Visual Studio.

## Related OrcaSlicer PRs

https://github.com/OrcaSlicer/OrcaSlicer/pull/11130