### PR TITLE
Update code block language and improve G-code examples

### DIFF
--- a/printer_settings/machine gcode/printer_machine_gcode.md
+++ b/printer_settings/machine gcode/printer_machine_gcode.md
@@ -100,7 +100,7 @@ This G-code is inserted when the extrusion role is changed.
 Example G-codes:
 
 - Marlin g-code to set fan speed to 10% (S25 out of S255) for BridgeInfill role and 30% (S75 out of S255) for other roles:
-  ```gcode
+  ```c++
   {if( extrusion_role == "BridgeInfill")}
   M106 S25
   {else}
@@ -108,9 +108,9 @@ Example G-codes:
   {endif}
   ```
   
-- Marlin G-code to set the fan speed to 0% for the ['Internal Sparse Infill' role](strength_settings_infill) and the first three layers, and to 30% (M106 S{0.3*255}) for the other roles. This achieves good layer adhesion while maintaining perimeter quality.:
-  ```gcode
-  {if(extrusion_role)=="InternalInfill"||layer_num <4}
+- Marlin G-code to set the fan speed to 0% for the ['Internal Sparse Infill' role](strength_settings_infill) and the first three layers, and to 30% `0.3*255` for the other roles. This achieves good layer adhesion while maintaining perimeter quality.:
+  ```c++
+  {if(extrusion_role)=="InternalInfill" || layer_num < 4 }
   M106 S0
   {else}
   M106 S{0.3*255}
@@ -118,7 +118,7 @@ Example G-codes:
   ```
   
 - Marlin g-code to set pressure advance to 0 for ['Internal Sparse Infill' role](strength_settings_infill) and restore it to previous value for other roles:
-  ```gcode
+  ```c++
   {if( extrusion_role == "InternalInfill")}
   M900 K0
   {else}


### PR DESCRIPTION
Changed code block language from 'gcode' to 'c++' for syntax highlighting and improved formatting in G-code examples. Also refined example conditions and descriptions for clarity.