### PR TITLE
Add warning about adaptive volumetric speed feature

### DIFF
--- a/material_settings/filament/material_volumetric_speed_limitation.md
+++ b/material_settings/filament/material_volumetric_speed_limitation.md
@@ -7,6 +7,10 @@ Each material profile includes a **maximum volumetric speed** setting, which lim
 
 ## Adaptive volumetric speed
 
+> [!WARNING]
+> Experimental and incomplete feature imported from BBS.  
+> Functional for some profiles that already have the variable saved.
+
 When enabled, the extrusion flow is limited by the smaller of the fitted value (calculated from line width and layer height) and the user-defined maximum flow. When disabled, only the user-defined maximum flow is applied.
 
 ## Max volumetric speed


### PR DESCRIPTION
Added a warning note indicating that the adaptive volumetric speed feature is experimental, incomplete, and imported from BBS. Clarifies that it is only functional for some profiles with the variable already saved.