### PR TITLE
Update Visual Studio solution file extension in docs

### DIFF
--- a/developer-reference/How-to-build.md
+++ b/developer-reference/How-to-build.md
@@ -118,7 +118,7 @@ How to building with Visual Studio on Windows 64-bit.
 
 3. If successful, you will find the Visual Studio solution file in:
    ```shell
-   build\OrcaSlicer.sln
+   build\OrcaSlicer.slnx
    ```
 4. Open the solution in Visual Studio, set the build configuration to `Release` and run the `Local Windows Debugger`.  
    ![compile_vs_local_debugger](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/develop/compile_vs_local_debugger.png?raw=true)


### PR DESCRIPTION
Changed the referenced solution file from 'OrcaSlicer.sln' to 'OrcaSlicer.slnx' in the Windows build instructions to reflect the correct file name.