### PR TITLE
Add mkdocs-gh-admonitions-plugin to deploy workflow

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install mkdocs
-        run: pip install mkdocs mkdocs-material pymdown-extensions
+        run: pip install mkdocs mkdocs-material pymdown-extensions mkdocs-gh-admonitions-plugin
 
       - name: Build wiki content
         run: |


### PR DESCRIPTION
Updated the GitHub Actions deploy-wiki workflow to install the mkdocs-gh-admonitions-plugin package. This enables support for admonitions in the wiki documentation build process.
