### PR TITLE
Update mkdocs admonitions plugin in deploy workflow

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install mkdocs
-        run: pip install mkdocs mkdocs-material pymdown-extensions mkdocs-gh-admonitions-plugin
+        run: pip install mkdocs mkdocs-material pymdown-extensions mkdocs-github-admonitions-plugin
 
       - name: Build wiki content
         run: |


### PR DESCRIPTION
Replaces mkdocs-gh-admonitions-plugin with mkdocs-github-admonitions-plugin in the GitHub Actions deploy-wiki workflow to use the correct package.
