### PR TITLE
Copy web_extras assets to wiki output in build scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -223,6 +223,14 @@ if (Test-Path "web_extras\OrcaSlicer.png") {
     Write-Host "Warning: web_extras\OrcaSlicer.png not found - skipping" -ForegroundColor Yellow
 }
 
+if (Test-Path "web_extras") {
+    New-Item -ItemType Directory -Path "wiki\web_extras" -Force | Out-Null
+    Copy-Item -Path "web_extras\*" -Destination "wiki\web_extras" -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Copied web_extras directory"
+} else {
+    Write-Host "Warning: web_extras directory not found - skipping" -ForegroundColor Yellow
+}
+
 Write-Host "`nBuild complete! HTML files are in the wiki/ folder." -ForegroundColor Green
 
 # === PREVENT WINDOW FROM CLOSING IMMEDIATELY WHEN DOUBLE-CLICKED ===

--- a/build.sh
+++ b/build.sh
@@ -179,4 +179,34 @@ create_redirects
 # Clean up docs directory after build
 rm -rf docs
 
+echo "Copying extra web assets to wiki folder..."
+mkdir -p wiki/assets/stylesheets
+mkdir -p wiki/assets/images
+
+# Copy shared assets that complement MkDocs' static site output
+if [ -f "web_extras/extra.css" ]; then
+  cp "web_extras/extra.css" wiki/assets/stylesheets/extra.css
+else
+  echo "Warning: web_extras/extra.css not found - skipping"
+fi
+
+if [ -f "web_extras/OrcaSlicer.ico" ]; then
+  cp "web_extras/OrcaSlicer.ico" wiki/assets/images/OrcaSlicer.ico
+else
+  echo "Warning: web_extras/OrcaSlicer.ico not found - skipping"
+fi
+
+if [ -f "web_extras/OrcaSlicer.png" ]; then
+  cp "web_extras/OrcaSlicer.png" wiki/assets/images/OrcaSlicer.png
+else
+  echo "Warning: web_extras/OrcaSlicer.png not found - skipping"
+fi
+
+if [ -d "web_extras" ]; then
+  mkdir -p wiki/web_extras
+  cp -r web_extras/* wiki/web_extras/ 2>/dev/null || true
+else
+  echo "Warning: web_extras directory not found - skipping"
+fi
+
 echo "Build complete! HTML files are in the wiki/ folder."


### PR DESCRIPTION
Enhances both build.ps1 and build.sh to copy the contents of the web_extras directory into the wiki output folder, ensuring extra assets are available in the generated site. Adds warnings if the web_extras directory or specific files are missing.

Based in https://github.com/OrcaSlicer/OrcaSlicer_WIKI/pull/80#issuecomment-3721438310