### PR TITLE
Styling improvements

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ theme:
       toggle:
         icon: material/weather-night
         name: Switch to light mode
+  font: false # default font only pulls font with 300, 400, 400i and 700 weight
+              # pulled fonts with CSS method. Fonts are pulled from Google and its same for Defaut behaviour
   
 extra_css:
   - assets/stylesheets/extra.css

--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -1,3 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&display=swap');
+
+:root {
+  --md-text-font: "Noto Sans", sans-serif;  /* Body text, headings */
+  --md-code-font: "Roboto Mono", monospace; /* Body text, headings */
+}
+
 :root,
 [data-md-color-scheme=default],
 [data-md-color-scheme=slate]{
@@ -72,7 +80,7 @@
         display:none;
     }
     /* Remove leftover margin for first item*/
-	.md-nav--primary .md-nav__item:nth-child(1) a{
+	.md-nav--primary>.md-nav__list>.md-nav__item:first-of-type>a{
 		margin-top: 0 !important;
 	}
 }
@@ -153,6 +161,10 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
 
 /* /////// LINKS */
 
+/* Make hyperlinks slightly bolder */
+.md-typeset a{
+    font-weight: 500;
+}
 /* Show underline on links while hovering */
 .md-typeset a:hover {
     text-decoration: underline;
@@ -271,6 +283,12 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
 /* Slighly reduce table cell height */
 .md-typeset table:not([class]) td {
     padding: .75em 1.25em;
+}
+
+/* /////// FOOTER */
+/* Fixes sidebar content rendering over footer when all items expanded */
+.md-footer{
+    z-index: 10;
 }
 
 /* /////// PAGE SPESIFIC CHANGES */


### PR DESCRIPTION
• Replaces sans font with Noto Sans (using same font on website as well)
• Mono space font is same as original but i have to set it again

• Hyperlinks now slightly bolder. this one is not possible before because 500 & 600 font weights doesnt exist. that was causing font weight jumps 400 to 700

• Fixed sidebar items overlapping on footer
• Fixed Sidebar items has wrong margins