### PR TITLE
Actions fix

### DIFF
--- a/.github/workflows/unreferenced_images.yml
+++ b/.github/workflows/unreferenced_images.yml
@@ -54,6 +54,7 @@ jobs:
               }
               for (const entry of entries) {
                 if (entry.name === '.git') continue;
+                if (relativeDir === 'images' && entry.isDirectory() && entry.name === 'misc') continue;
                 const rel = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
                 if (entry.isDirectory()) {
                   files.push(...collectFilesUnder(rel, extSet));


### PR DESCRIPTION
This pull request introduces a small change to the `.github/workflows/unreferenced_images.yml` workflow. The update ensures that the `misc` directory under `images` is skipped during the collection of files, preventing it from being processed in the workflow.

I did this to avoid errors caused by images not being referenced on the scale, because not all values on the scale are always used.