### PR TITLE
Remove image limit size for tables

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -285,11 +285,12 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     padding: .75em 1.25em;
 }
 
-/* Keep the pattern icons at a fixed height inside tables */
-.md-typeset table img[alt^="param_"] {
-    height: 45px;
-    width: auto;
+/* Let table images respect their explicit dimensions */
+.md-typeset table img {
     max-width: none;
+    max-height: none;
+    width: auto;
+    height: unset;
 }
 
 /* /////// FOOTER */


### PR DESCRIPTION
This pull request makes a targeted CSS update to improve how images are displayed inside tables. Specifically, it ensures that images in tables respect their explicitly set dimensions, rather than being constrained by parent styles.