### PR TITLE
Add !important to image height unset rule

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -290,7 +290,7 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     max-width: none;
     max-height: none;
     width: auto;
-    height: unset;
+    height: unset !important;
 }
 
 /* /////// FOOTER */


### PR DESCRIPTION
Updated the CSS rule for images to use 'height: unset !important;' to ensure the unset value takes precedence over other styles.