### PR TITLE
Vertically align images in markdown content

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -158,6 +158,13 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     margin-left: 0.2em;
 }
 
+/* /////// Images */
+
+/* Vertically align images to make it inline with text */
+.md-typeset img {
+    vertical-align: middle;
+}
+
 
 /* /////// LINKS */
 


### PR DESCRIPTION
Added CSS rule to vertically align images to the middle within elements using the .md-typeset class, ensuring images are inline with surrounding text.

Before
<img width="352" height="468" alt="imagen" src="https://github.com/user-attachments/assets/98d510a4-7c3d-46b8-80df-a7f62284bc4c" />

After
<img width="352" height="468" alt="imagen" src="https://github.com/user-attachments/assets/dcb5574a-bca5-4d87-883b-3655b73e8698" />