### PR TITLE
Override image height to respect explicit attributes

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -237,7 +237,7 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     margin-bottom: .4rem;
 }
 
-.md-typeset .admonition>:last-child, 
+.md-typeset .admonition>:last-child,
 .md-typeset details>:last-child {
     margin-bottom: 0;
     margin-block-start: 0.3em;
@@ -325,4 +325,9 @@ head:has(link[rel="canonical"][href$="keyboard-shortcuts.html"])~body td>code {
   background-color: transparent;
   color: var(--md-typeset-color);
   font-weight: 550;
+}
+
+/* Override theme's height: auto for images to respect explicit height attributes */
+.md-typeset img {
+  height: unset;
 }


### PR DESCRIPTION
Added CSS rule to unset the theme's automatic height for images, ensuring that explicit height attributes on <img> elements are respected.
Fix icons not using the set size:
<img width="397" height="625" alt="imagen" src="https://github.com/user-attachments/assets/14eeb62f-dbde-4d8f-b47b-da20192db9a2" />
