### PR TITLE
Use 'revert' for image height override in CSS

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -329,5 +329,5 @@ head:has(link[rel="canonical"][href$="keyboard-shortcuts.html"])~body td>code {
 
 /* Override theme's height: auto for images to respect explicit height attributes */
 .md-typeset img {
-  height: unset;
+  height: revert;
 }


### PR DESCRIPTION
Changed the image height override from 'unset' to 'revert' in .md-typeset img to better respect explicit height attributes and restore default behavior when needed.