### PR TITLE
Add specific height styles for images

### DIFF
--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -165,6 +165,15 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     vertical-align: middle;
 }
 
+img[height="22"] { /* Text icons */
+    height: 22px;
+}
+img[height="45"] { /* Patterns table */
+    height: 45px;
+}
+img[height="200"] { /* Calibrations guide preview */
+    height: 200px;
+}
 
 /* /////// LINKS */
 
@@ -237,7 +246,7 @@ h1 + ol, h2 + ol, h3 + ol, h4 + ol{
     margin-bottom: .4rem;
 }
 
-.md-typeset .admonition>:last-child, 
+.md-typeset .admonition>:last-child,
 .md-typeset details>:last-child {
     margin-bottom: 0;
     margin-block-start: 0.3em;


### PR DESCRIPTION
Introduced CSS rules to set explicit heights for images with height attributes of 22, 45, and 200 pixels, targeting text icons, patterns table, and calibrations guide preview.