### PR TITLE
Expand list pattern matching in checklist validation

### DIFF
--- a/.github/workflows/validate_checklist_indentation.yml
+++ b/.github/workflows/validate_checklist_indentation.yml
@@ -70,9 +70,9 @@ jobs:
               lines.forEach((line, index) => {
                 const lineNum = index + 1;
 
-                // Match checklist patterns: "- [ ]", "- [x]", "[number]. [ ]", etc.
-                const checklistPattern = /^(\s*)(?:[-*]|\d+\.)\s+\[[\sx]\]/;
-                const match = line.match(checklistPattern);
+                // Match ALL list patterns: "- ", "* ", "[number]. "
+                const listPattern = /^(\s*)(?:[-*]|\d+\.)\s+/;
+                const match = line.match(listPattern);
 
                 if (match) {
                   const indentation = match[1].length;


### PR DESCRIPTION
Updated the regex to match all list patterns (e.g., '- ', '* ', '1. ') instead of only checklist items. This allows the workflow to validate indentation for all list types, not just checklists.