### PR TITLE
Preserve URL hash in HTML redirects

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -207,10 +207,16 @@ Get-ChildItem -Path wiki -Filter *.html -Recurse | Where-Object { $_.Name -ne 'i
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url=$encodedUrl">
-  <link rel="canonical" href="$encodedUrl">
-  <script>window.location.replace("$encodedUrl");</script>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=$encodedUrl">
+    <link rel="canonical" href="$encodedUrl">
+    <script>
+        (function() {
+            var hash = window.location.hash || "";
+            var target = "$encodedUrl" + hash;
+            window.location.replace(target);
+        })();
+    </script>
 </head>
 <body>
   <p>Redirecting to <a href="$encodedUrl">$filename</a>...</p>

--- a/build.sh
+++ b/build.sh
@@ -183,7 +183,13 @@ create_redirects() {
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=${encoded_url}">
   <link rel="canonical" href="${encoded_url}">
-  <script>window.location.replace("${encoded_url}");</script>
+  <script>
+    (function() {
+      var hash = window.location.hash || "";
+      var target = "${encoded_url}" + hash;
+      window.location.replace(target);
+    })();
+  </script>
 </head>
 <body>
   <p>Redirecting to <a href="${encoded_url}">${filename}</a>...</p>


### PR DESCRIPTION
Updated the redirect scripts in build.ps1 and build.sh to append the current URL hash to the target URL, ensuring that anchor links are preserved during redirection.

Fixes #140