### PR TITLE
Add tip for sharing PR artifacts guide

### DIFF
--- a/developer-reference/How-to-download-PR-artifacts.md
+++ b/developer-reference/How-to-download-PR-artifacts.md
@@ -21,3 +21,10 @@ When a Pull Request (PR) is created or updated in the [OrcaSlicer repository](ht
         - `OrcaSlicer-Linux-flatpak_[PR_NUMBER]_aarch64.flatpak` : Flatpak for ARM64.
         - `OrcaSlicer_Linux_ubuntu_2404_[PR_NUMBER]` : Ubuntu 24.04 DEB package.
 7. Once downloaded, extract the ZIP file to access the build artifacts.
+
+> [!TIP]
+> Share this guide to others!
+>
+> ```css
+> https://www.orcaslicer.com/wiki/How-to-download-PR-artifacts
+> ```


### PR DESCRIPTION
Added a tip section at the end of the guide with a link to the online documentation for downloading PR artifacts, making it easier for users to share the instructions.