### PR TITLE
Clarify jerk and junction deviation docs

### DIFF
--- a/.github/workflows/validate_internal_link.yml
+++ b/.github/workflows/validate_internal_link.yml
@@ -333,7 +333,7 @@ jobs:
             }
 
             function isKebabCase(value) {
-              return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+              return /^[a-z0-9]+(?:-+[a-z0-9]+)*$/.test(value);
             }
 
             function decodeLinkComponent(value) {

--- a/print_settings/speed/speed_settings_jerk_xy.md
+++ b/print_settings/speed/speed_settings_jerk_xy.md
@@ -2,32 +2,9 @@
 
 **Jerk** is the rate of change of acceleration and how quickly your printer can change between different accelerations. It controls direction changes and velocity transitions during movement.
 
-## Cornering Control Types
-
-- **Jerk**: Traditional method, sets a maximum speed for direction changes.
-    - Klipper: [Square corner velocity](https://www.klipper3d.org/Config_Reference.html#printer)
-    - RepRapFirmware: [Maximum instantaneous speed changes](https://docs.duet3d.com/User_manual/Reference/Gcodes#m566-set-allowable-instantaneous-speed-change)
-    - Marlin 2: [Classic Jerk](https://marlinfw.org/docs/configuration/configuration.html#jerk-) (deprecated in favor of [Junction Deviation](https://marlinfw.org/docs/configuration/configuration.html#junction-deviation-)) but can still be used.
-    - Marlin Legacy: [Classic Jerk](https://marlinfw.org/docs/configuration/configuration.html#jerk-).
-- **[Junction Deviation](#junction-deviation)**: Modern method, calculates cornering speed based on acceleration and speed.
-
-> [!TIP]
-> Calibrate your Cornering Values using the [Cornering Calibration guide](cornering_calib).
-
-## Key Effects
-
-- **Corner Control**: Lower values = smoother corners, better quality. Higher values = faster cornering, potential artifacts
-- **Print Speed**: Higher jerk reduces deceleration at direction changes, increasing overall speed
-- **Surface Quality**: Lower jerk minimizes vibrations and ringing, especially important for outer walls
-
-This setting overrides firmware jerk values when different motion types need specific settings. Orca limits jerk to not exceed the Printer's Motion Ability settings.
-
-> [!TIP]
-> Jerk can work in conjunction with [Pressure Advance](pressure_advance_calib), [Adaptive Pressure Advance](adaptive_pressure_advance_calib), and [Input Shaping](input_shaping_calib) to optimize print quality and speed.  
-> It's recommended to follow the [calibration guide](calibration_guide) order for best results.
-
-- [Cornering Control Types](#cornering-control-types)
 - [Key Effects](#key-effects)
+- [Cornering Control Types](#cornering-control-types)
+    - [Junction Deviation](#junction-deviation)
 - [Default](#default)
     - [Outer wall](#outer-wall)
     - [Inner wall](#inner-wall)
@@ -35,8 +12,51 @@ This setting overrides firmware jerk values when different motion types need spe
     - [Top surface](#top-surface)
     - [Initial layer](#initial-layer)
     - [Travel](#travel)
-- [Junction Deviation](#junction-deviation)
 - [Useful links](#useful-links)
+
+## Key Effects
+
+- **Corner Control**:
+    - Lower values = smoother corners, better quality.
+    - Higher values = faster cornering, potential artifacts.
+- **Print Speed**: Higher jerk reduces deceleration at direction changes, increasing overall speed.
+- **Surface Quality**: Lower jerk minimizes vibrations and ringing, especially important for outer walls.
+
+This setting overrides firmware jerk values when different motion types need specific settings. Orca limits jerk to not exceed the Printer's Motion Ability settings.
+
+> [!TIP]
+> Jerk can work in conjunction with [Pressure Advance](pressure_advance_calib), [Adaptive Pressure Advance](adaptive_pressure_advance_calib), and [Input Shaping](input_shaping_calib) to optimize print quality and speed.  
+> It's recommended to follow the [calibration guide](calibration_guide) order for best results.
+
+## Cornering Control Types
+
+- **Jerk**: Traditional method, sets a maximum speed for direction changes.
+    - Klipper: [Square corner velocity](https://www.klipper3d.org/Config_Reference.html#printer)
+    - RepRapFirmware: [Maximum instantaneous speed changes](https://docs.duet3d.com/User_manual/Reference/Gcodes#m566-set-allowable-instantaneous-speed-change)
+    - Marlin 2: [Classic Jerk](https://marlinfw.org/docs/configuration/configuration.html#jerk-) (deprecated in favor of [Junction Deviation](https://marlinfw.org/docs/configuration/configuration.html#junction-deviation-)) but can still be used.
+    - Marlin Legacy: [Classic Jerk](https://marlinfw.org/docs/configuration/configuration.html#jerk-).
+- **[Junction Deviation](#junction-deviation)**: Modern method, calculates cornering speed based on acceleration.
+
+> [!TIP]
+> Calibrate your Cornering Values using the [Cornering Calibration guide](cornering_calib).
+
+### Junction Deviation
+
+[Variable](built_in_placeholders_variables): `default_junction_deviation`.  
+Alternative to Jerk, Junction Deviation is the default method for controlling cornering speed in Marlin 2 printers.  
+Instead of setting a cornering speed for each line type, it calculates the cornering speed based on the [each line's acceleration](speed_settings_acceleration) and speed using the formula:
+
+$$
+JD = 0,4 \cdot \frac{\text{Jerk}^2}{\text{Accel.}}
+$$
+
+Higher values result in faster and more aggressive cornering speeds, while lower values produce smoother, more controlled cornering.
+
+> [!NOTE]
+> Classic Jerk can still be used in Marlin 2, but it is deprecated in favor of Junction Deviation.  
+> If your printer uses Classic Jerk, you need to set your Junction Deviation to `0` to enable the use of Classic Jerk.
+
+This value is limited by [Printer settings > Motion ability > Maximum Junction Deviation](printer_motion_ability#maximum-junction-deviation).
 
 ## Default
 
@@ -75,22 +95,6 @@ Jerk for initial layer printing. This is usually set to a lower value than top s
 
 [Variable](built_in_placeholders_variables): `travel_jerk`.  
 Jerk for travel printing. This is usually set to a higher value than infill to reduce travel time.
-
-## Junction Deviation
-
-[Variable](built_in_placeholders_variables): `default_junction_deviation`.  
-Alternative to Jerk, Junction Deviation is the default method for controlling cornering speed in Marlin 2 printers.  
-Higher values result in more aggressive cornering speeds, while lower values produce smoother, more controlled cornering.
-
-> [!NOTE]
-> Classic Jerk can still be used in Marlin 2, but it is deprecated in favor of Junction Deviation.  
-> If your printer uses Classic Jerk, you need to set your Junction Deviation to `0` to enable the use of Classic Jerk.
-
-This value will **only be overwritten** if it is lower than the Junction Deviation value set in Printer settings > Motion ability. If it is higher, the value configured in Motion ability will be used.
-
-$$
-JD = 0,4 \cdot \frac{\text{Jerk}^2}{\text{Accel.}}
-$$
 
 ## Useful links
 

--- a/printer_settings/motion ability/printer_motion_ability.md
+++ b/printer_settings/motion ability/printer_motion_ability.md
@@ -8,8 +8,8 @@ Settings related to the motion capabilities of the printer.
 - [Speed limitation](#speed-limitation)
 - [Acceleration limitation](#acceleration-limitation)
 - [Jerk limitation](#jerk-limitation)
-    - [Maximum Junction Deviation](#maximum-junction-deviation)
     - [Maximum Jerk](#maximum-jerk)
+    - [Maximum Junction Deviation](#maximum-junction-deviation)
 
 ## Emit limits to G-code
 
@@ -47,12 +47,12 @@ Safeguard maximum jerks for all axes.
 > [!TIP]
 > Check the [Cornering Calibration](cornering_calib).
 
-### Maximum Junction Deviation
-
-[Variable](built_in_placeholders_variables): `machine_max_junction_deviation`.  
-Maximum junction deviation (M205 J, only apply if JD > 0 for Marlin Firmware. If your Marlin 2 printer uses Classic Jerk set this value to 0.)
-
 ### Maximum Jerk
 
 [Variables](built_in_placeholders_variables): `machine_max_jerk_z`, `machine_max_jerk_x`, `machine_max_jerk_y`, `machine_max_jerk_e`.  
-Maximum jerk for each axis (M205 X, Y, Z, E, only apply if JD = 0 for Marlin 2 Firmware)
+Maximum [jerk](speed_settings_jerk_xy) for each axis (M205 X, Y, Z, E, only apply if JD = 0 for Marlin 2 Firmware)
+
+### Maximum Junction Deviation
+
+[Variable](built_in_placeholders_variables): `machine_max_junction_deviation`.  
+Maximum [junction deviation](speed_settings_jerk_xy#junction-deviation) (M205 J, only apply if JD > 0 for Marlin Firmware. If your Marlin 2 printer uses Classic Jerk set this value to 0.)


### PR DESCRIPTION
Refactor and expand documentation for cornering control in speed_settings_jerk_xy.md: add a Key Effects section, reorganize Cornering Control Types, consolidate and clarify Junction Deviation (include formula, tips, and notes about Marlin/Classic Jerk), remove duplicated content, and explain how Orca limits jerk to Printer Motion Ability. Update printer_settings/motion ability/printer_motion_ability.md: reorder sections to place Maximum Junction Deviation after Maximum Jerk, update variable descriptions and link references, and clarify when M205 J/X/Y/Z/E apply.
