### PR TITLE
Update mkdocs to include Transfer/Discard Changes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
 - "General Settings":
   - "Import and Export": general_settings/import_export.md
   - "Keyboard Shortcuts": general_settings/keyboard_shortcuts.md
+  - "Transfer or Discard Changes popup dialog": general_settings/transfer_discard_changes.md
 - "Material Settings":
   - Cooling:
     - "Material Cooling": material_settings/cooling/material_cooling.md


### PR DESCRIPTION
Add a new navigation entry under "General Settings" in mkdocs.yml for the "Transfer or Discard Changes popup dialog" page, pointing to general_settings/transfer_discard_changes.md. This exposes the new documentation page in the site navigation.