### PR TITLE
Add initial layer travel accel and jerk docs

### DIFF
--- a/print_settings/speed/speed_settings_acceleration.md
+++ b/print_settings/speed/speed_settings_acceleration.md
@@ -11,6 +11,7 @@ Orca will limit the acceleration to not exceed the acceleration set in the Print
 - [Sparse infill](#sparse-infill)
 - [Internal solid infill](#internal-solid-infill)
 - [Initial layer](#initial-layer)
+- [Initial layer travel](#initial-layer-travel)
 - [Top surface](#top-surface)
 - [Travel](#travel)
 
@@ -51,6 +52,12 @@ Acceleration of [internal solid infill](speed_settings_other_layers_speed#intern
 
 [Variable](built_in_placeholders_variables): `initial_layer_acceleration`.  
 Acceleration of [initial layer](speed_settings_initial_layer_speed). Using a lower value can improve build plate adhesion.
+
+## Initial layer travel
+
+[Variable](built_in_placeholders_variables): `initial_layer_travel_acceleration`.  
+Acceleration of [initial layer travel](speed_settings_initial_layer_speed#initial-layer-travel-speed).
+Using a lower value can improve build plate adhesion. If the value is expressed as a percentage (e.g. 50%), it will be calculated based on the [Travel Acceleration](#travel).
 
 ## Top surface
 

--- a/print_settings/speed/speed_settings_jerk_xy.md
+++ b/print_settings/speed/speed_settings_jerk_xy.md
@@ -11,6 +11,7 @@
     - [Infill](#infill)
     - [Top surface](#top-surface)
     - [Initial layer](#initial-layer)
+    - [Initial layer travel](#initial-layer-travel)
     - [Travel](#travel)
 - [Useful links](#useful-links)
 
@@ -90,6 +91,12 @@ Jerk for top surface printing. This is usually set to a lower value than infill 
 
 [Variable](built_in_placeholders_variables): `initial_layer_jerk`.  
 Jerk for initial layer printing. This is usually set to a lower value than top surface to improve adhesion.
+
+### Initial layer travel
+
+[Variable](built_in_placeholders_variables): `initial_layer_travel_jerk`.  
+Jerk for initial layer travel.
+Using a lower value can improve build plate adhesion. If the value is expressed as a percentage (e.g. 50%), it will be calculated based on the [Travel Jerk](#travel).
 
 ### Travel
 


### PR DESCRIPTION
Add "Initial layer travel" sections to acceleration and jerk documentation. Introduces variables `initial_layer_travel_acceleration` and `initial_layer_travel_jerk`, notes that lowering these can improve build plate adhesion, and explains percentage values are calculated relative to Travel Acceleration/Jerk.