### PR TITLE
Parse assigned append_line blocks and option indexers

### DIFF
--- a/material_settings/cooling/material_cooling.md
+++ b/material_settings/cooling/material_cooling.md
@@ -139,8 +139,10 @@ G-code command: `M106 P3 S(0-255)`
 
 #### During print
 
+[Variables](built_in_placeholders_variables): `activate_air_filtration_during_print`, `during_print_exhaust_fan_speed`.  
 Speed of exhaust fan during printing. This speed will override the speed in filament custom G-code.
 
 #### Complete print
 
+[Variables](built_in_placeholders_variables): `activate_air_filtration_on_completion`, `complete_print_exhaust_fan_speed`.  
 Speed of exhaust fan after printing completes.

--- a/material_settings/filament/material_temperatures.md
+++ b/material_settings/filament/material_temperatures.md
@@ -32,6 +32,7 @@ Always refer to the filament manufacturer's recommendations and [calibrations](t
 
 ## Nozzle
 
+[Variables](built_in_placeholders_variables): `nozzle_temperature_initial_layer`, `nozzle_temperature`.  
 One of the most critical settings for successful 3D printing is the nozzle temperature.  
 The correct nozzle temperature ensures proper melting and extrusion of the filament, leading to good layer adhesion and overall print quality.  
 You can set a higher temperature for the first layer to improve bed adhesion but be cautious with deformations as [elephant foot](quality_settings_precision#elephant-foot-compensation).

--- a/print_settings/quality/quality_settings_wall_and_surfaces.md
+++ b/print_settings/quality/quality_settings_wall_and_surfaces.md
@@ -79,7 +79,7 @@ Other flow ratios, such as ratios for the first layer (does not affect brims and
 
 ## Only one wall
 
-[Variables](built_in_placeholders_variables): `only_one_wall_top`, `only_one_wall_first_layer`.  
+[Variables](built_in_placeholders_variables): `only_one_wall_first_layer`, `only_one_wall_top`.  
 Use only one wall on flat surfaces, to give more space to the [top infill pattern](strength_settings_top_bottom_shells#surface-pattern).
 Specially useful in small features, like letters, where the top surface is very small and [concentric pattern](strength_settings_patterns#concentric) from walls would not cover it properly.
 

--- a/printer_settings/motion ability/printer_motion_ability.md
+++ b/printer_settings/motion ability/printer_motion_ability.md
@@ -36,7 +36,7 @@ This will cap the speed set by the process if it exceeds these values.
 
 ## Acceleration limitation
 
-[Variables](built_in_placeholders_variables): `machine_max_acceleration_x`, `machine_max_acceleration_y`, `machine_max_acceleration_z`, `machine_max_acceleration_e`, `machine_max_acceleration_extruding`, `machine_max_acceleration_retracting`, `machine_max_acceleration_travel`.  
+[Variables](built_in_placeholders_variables): `machine_max_acceleration_x`, `machine_max_acceleration_y`, `machine_max_acceleration_e`, `machine_max_acceleration_z`, `machine_max_acceleration_extruding`, `machine_max_acceleration_retracting`, `machine_max_acceleration_travel`.  
 Safeguard maximum accelerations for all axes.
 This will cap the acceleration set by the process if it exceeds these values.
 
@@ -49,7 +49,7 @@ Safeguard maximum jerks for all axes.
 
 ### Maximum Jerk
 
-[Variables](built_in_placeholders_variables): `machine_max_jerk_z`, `machine_max_jerk_x`, `machine_max_jerk_y`, `machine_max_jerk_e`.  
+[Variables](built_in_placeholders_variables): `machine_max_jerk_y`, `machine_max_jerk_x`, `machine_max_jerk_z`, `machine_max_jerk_e`.  
 Maximum [jerk](speed_settings_jerk_xy) for each axis (M205 X, Y, Z, E, only apply if JD = 0 for Marlin 2 Firmware)
 
 ### Maximum Junction Deviation

--- a/sync-tab-options-to-wiki.ps1
+++ b/sync-tab-options-to-wiki.ps1
@@ -88,12 +88,58 @@ function Get-StringVectors {
     return $result
 }
 
+$syncProgressActivity = "sync-tab-options-to-wiki.ps1"
+$syncStageTotal = 7
+
+function Set-SyncStage {
+    param(
+        [int]$Step,
+        [string]$Status
+    )
+
+    $percent = if ($syncStageTotal -gt 0) {
+        [Math]::Max(0, [Math]::Min(100, [int](($Step / [double]$syncStageTotal) * 100)))
+    }
+    else {
+        0
+    }
+
+    Write-Progress -Id 1 -Activity $syncProgressActivity -Status $Status -PercentComplete $percent
+}
+
+function Set-SyncDetail {
+    param(
+        [string]$Status,
+        [int]$Current,
+        [int]$Total
+    )
+
+    $percent = if ($Total -gt 0) {
+        [Math]::Max(0, [Math]::Min(100, [int](($Current / [double]$Total) * 100)))
+    }
+    else {
+        0
+    }
+
+    Write-Progress -Id 2 -ParentId 1 -Activity "Processing markdown mappings" -Status $Status -PercentComplete $percent
+}
+
+function Complete-SyncProgress {
+    Write-Progress -Id 2 -Activity "Processing markdown mappings" -Completed
+    Write-Progress -Id 1 -Activity $syncProgressActivity -Completed
+}
+
+Set-SyncStage -Step 0 -Status "Validating input paths"
+
 if (-not (Test-Path -LiteralPath $WikiRoot)) {
+    Complete-SyncProgress
     throw "Wiki root not found: $WikiRoot"
 }
 
+Set-SyncStage -Step 1 -Status "Loading Tab.cpp content"
 $tabContent = Get-TabCppContent -Source $TabCppPath
 
+Set-SyncStage -Step 2 -Status "Parsing option mappings from Tab.cpp"
 $patternSingle = 'append_single_option_line\(\s*"(?<variable>[^"]+)"\s*,\s*"(?<ref>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\s*\)'
 $patternOption = 'append_option_line\(\s*[^,]+\s*,\s*"(?<variable>[^"]+)"\s*,\s*"(?<ref>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\s*\)'
 $patternAppendLineBlock = '(?s)(?<obj>\w+)\.label_path\s*=\s*"(?<ref>[^"]+)"\s*;(?<body>.*?)(?:\w+->)?append_line\(\s*\k<obj>\s*\)\s*;'
@@ -235,9 +281,11 @@ $parsedMatches = @($rawEntries | Sort-Object -Property Index)
 
 if ($parsedMatches.Count -eq 0) {
     Write-Host "No supported option-to-doc mappings were found." -ForegroundColor Yellow
+    Complete-SyncProgress
     exit 0
 }
 
+Set-SyncStage -Step 3 -Status "Scanning markdown files"
 $mdFiles = Get-ChildItem -LiteralPath $WikiRoot -Recurse -File -Filter '*.md' |
     Where-Object { $_.FullName -notmatch '[\\/]wiki[\\/]' }
 
@@ -250,6 +298,7 @@ foreach ($file in $mdFiles) {
     $mdByName[$key].Add($file.FullName)
 }
 
+Set-SyncStage -Step 4 -Status "Building file and anchor entries"
 $entries = New-Object System.Collections.Generic.List[object]
 foreach ($m in $parsedMatches) {
     $variable = $m.Variable
@@ -277,6 +326,7 @@ foreach ($m in $parsedMatches) {
 
 if ($entries.Count -eq 0) {
     Write-Host "No entries with file#anchor format were found." -ForegroundColor Yellow
+    Complete-SyncProgress
     exit 0
 }
 
@@ -287,9 +337,15 @@ $alreadyPresent = 0
 $normalizedSections = 0
 
 $groupedByFile = $entries | Group-Object -Property FileKey
+$totalFileGroups = $groupedByFile.Count
+$fileNumber = 0
+
+Set-SyncStage -Step 5 -Status "Applying mappings to markdown files ($totalFileGroups files)"
 
 foreach ($group in $groupedByFile) {
+    $fileNumber++
     $fileKey = $group.Name
+    Set-SyncDetail -Status "File $fileNumber/$($totalFileGroups): $fileKey" -Current $fileNumber -Total $totalFileGroups
 
     if (-not $mdByName.ContainsKey($fileKey)) {
         Write-Host "[WARN] Markdown file not found for '$fileKey'" -ForegroundColor Yellow
@@ -310,8 +366,12 @@ foreach ($group in $groupedByFile) {
     $fileChanged = $false
 
     $groupedByAnchor = $group.Group | Group-Object -Property Anchor
+    $anchorCount = $groupedByAnchor.Count
+    $anchorNumber = 0
 
     foreach ($anchorGroup in $groupedByAnchor) {
+        $anchorNumber++
+        Set-SyncDetail -Status "File $fileNumber/$($totalFileGroups): $fileKey | Anchor $anchorNumber/$($anchorCount): $($anchorGroup.Name)" -Current $fileNumber -Total $totalFileGroups
         $anchor = $anchorGroup.Name
 
         $vars = New-Object System.Collections.Generic.List[string]
@@ -397,6 +457,7 @@ foreach ($group in $groupedByFile) {
     }
 }
 
+Set-SyncStage -Step 6 -Status "Finalizing summary"
 Write-Host "Processed: $($entries.Count) entries"
 Write-Host "Inserted:  $changes"
 Write-Host "Skipped (already present): $alreadyPresent"
@@ -407,3 +468,6 @@ Write-Host "Missing heading anchors: $missingHeadings"
 if ($DryRun) {
     Write-Host "Dry run only. No files were modified." -ForegroundColor Cyan
 }
+
+Set-SyncStage -Step 7 -Status "Completed"
+Complete-SyncProgress

--- a/sync-tab-options-to-wiki.ps1
+++ b/sync-tab-options-to-wiki.ps1
@@ -97,11 +97,13 @@ $tabContent = Get-TabCppContent -Source $TabCppPath
 $patternSingle = 'append_single_option_line\(\s*"(?<variable>[^"]+)"\s*,\s*"(?<ref>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\s*\)'
 $patternOption = 'append_option_line\(\s*[^,]+\s*,\s*"(?<variable>[^"]+)"\s*,\s*"(?<ref>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\s*\)'
 $patternAppendLineBlock = '(?s)(?<obj>\w+)\.label_path\s*=\s*"(?<ref>[^"]+)"\s*;(?<body>.*?)(?:\w+->)?append_line\(\s*\k<obj>\s*\)\s*;'
+$patternAppendLineAssignedBlock = '(?s)(?<obj>\w+)\s*=\s*\{.*?\}\s*;(?<body>.*?)(?:\w+->)?append_line\(\s*\k<obj>\s*\)\s*;'
 $patternForBlock = '(?s)for\s*\(\s*const\s+std::string\s*&\s*(?<iter>\w+)\s*:\s*(?<collection>\w+)\s*\)\s*\{(?<body>.*?)\}'
 
 $singleMatches = [regex]::Matches($tabContent, $patternSingle)
 $optionMatches = [regex]::Matches($tabContent, $patternOption)
 $appendLineMatches = [regex]::Matches($tabContent, $patternAppendLineBlock)
+$appendLineAssignedMatches = [regex]::Matches($tabContent, $patternAppendLineAssignedBlock)
 $forMatches = [regex]::Matches($tabContent, $patternForBlock)
 $stringVectors = Get-StringVectors -Content $tabContent
 
@@ -139,12 +141,47 @@ foreach ($m in $appendLineMatches) {
     $obj = $m.Groups['obj'].Value
     $ref = $m.Groups['ref'].Value.Trim()
     $body = $m.Groups['body'].Value
-    $optPattern = [regex]::Escape($obj) + '\.append_option\(\s*optgroup->get_option\("(?<variable>[^"]+)"\)\s*\)\s*;'
+    $optPattern = '(?s)' + [regex]::Escape($obj) + '\.append_option\(\s*.*?get_option\("(?<variable>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\)\s*\)\s*;'
     $optMatches = [regex]::Matches($body, $optPattern)
 
     foreach ($om in $optMatches) {
+        $variable = $om.Groups['variable'].Value.Trim()
+        $indexer = $om.Groups['indexer'].Value.Trim()
+        if (-not [string]::IsNullOrWhiteSpace($indexer) -and $indexer -match '^[A-Za-z_]\w*$') {
+            $variable = "${variable}[$indexer]"
+        }
+
         $rawEntries.Add([PSCustomObject]@{
-            Variable = $om.Groups['variable'].Value.Trim()
+            Variable = $variable
+            Ref      = $ref
+            Index    = [int]($m.Index + $om.Index)
+        })
+    }
+}
+
+foreach ($m in $appendLineAssignedMatches) {
+    $obj = $m.Groups['obj'].Value
+    $body = $m.Groups['body'].Value
+
+    $labelPattern = [regex]::Escape($obj) + '\.label_path\s*=\s*"(?<ref>[^"]+)"\s*;'
+    $labelMatch = [regex]::Match($body, $labelPattern)
+    if (-not $labelMatch.Success) {
+        continue
+    }
+
+    $ref = $labelMatch.Groups['ref'].Value.Trim()
+    $optPattern = '(?s)' + [regex]::Escape($obj) + '\.append_option\(\s*.*?get_option\("(?<variable>[^"]+)"(?:\s*,\s*(?<indexer>[^\)]+))?\)\s*\)\s*;'
+    $optMatches = [regex]::Matches($body, $optPattern)
+
+    foreach ($om in $optMatches) {
+        $variable = $om.Groups['variable'].Value.Trim()
+        $indexer = $om.Groups['indexer'].Value.Trim()
+        if (-not [string]::IsNullOrWhiteSpace($indexer) -and $indexer -match '^[A-Za-z_]\w*$') {
+            $variable = "${variable}[$indexer]"
+        }
+
+        $rawEntries.Add([PSCustomObject]@{
+            Variable = $variable
             Ref      = $ref
             Index    = [int]($m.Index + $om.Index)
         })
@@ -193,9 +230,10 @@ foreach ($fm in $forMatches) {
     }
 }
 
-$matches = @($rawEntries | Sort-Object -Property Index)
 
-if ($matches.Count -eq 0) {
+$parsedMatches = @($rawEntries | Sort-Object -Property Index)
+
+if ($parsedMatches.Count -eq 0) {
     Write-Host "No supported option-to-doc mappings were found." -ForegroundColor Yellow
     exit 0
 }
@@ -213,7 +251,7 @@ foreach ($file in $mdFiles) {
 }
 
 $entries = New-Object System.Collections.Generic.List[object]
-foreach ($m in $matches) {
+foreach ($m in $parsedMatches) {
     $variable = $m.Variable
     $ref = $m.Ref
 


### PR DESCRIPTION
This pull request introduces improvements to documentation and significantly enhances the `sync-tab-options-to-wiki.ps1` script by adding detailed progress reporting and improving parsing logic. The changes ensure better tracking of sync progress and provide more robust handling of option-to-doc mappings.

Enhancements to sync script progress reporting and robustness:

* Added progress reporting functions (`Set-SyncStage`, `Set-SyncDetail`, `Complete-SyncProgress`) to the `sync-tab-options-to-wiki.ps1` script, providing real-time feedback on sync stages and details. Progress is now shown for each major step and for each file and anchor processed. [[1]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR91-R152) [[2]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR340-R348) [[3]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR369-R374) [[4]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR460) [[5]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR471-R473)
* Improved error handling and early exits in the sync script by marking progress as complete on failure or when no mappings are found. [[1]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcL196-R288) [[2]](diffhunk://#diff-c99c3ffeb11f4fb901a650dd9579da3475ec60b59cbf4619bf59469e5eda68bcR329)
* Enhanced parsing logic to support additional option mapping patterns, especially for assigned block structures in `Tab.cpp`. This increases the accuracy and completeness of variable-to-documentation mappings.
* Improved handling of option variables with indexers in parsing, ensuring variables like `option[index]` are correctly recognized and mapped.

Documentation updates for clarity and consistency:

* Updated the order and content of listed variables in several markdown files for clarity and consistency, including `material_cooling.md`, `material_temperatures.md`, `quality_settings_wall_and_surfaces.md`, and `printer_motion_ability.md`. [[1]](diffhunk://#diff-e49f2b91428ab0754b7181a6f0a32617ac6445c6d3c387a1cfa7d3e1559757caR142-R147) [[2]](diffhunk://#diff-888a716b377a601c55cc405752d615caf4fc3ac5b489dc471477e71dee6bcbc3R35) [[3]](diffhunk://#diff-36ac7f5abded60bf3a9cddab88681a4e07a03f52fd3c557365572d88ce80aeeaL82-R82) [[4]](diffhunk://#diff-34ede647abeaca4000ac3483e793a235fc0dc6985ce590e61a3ea01e59d5331aL39-R39) [[5]](diffhunk://#diff-34ede647abeaca4000ac3483e793a235fc0dc6985ce590e61a3ea01e59d5331aL52-R52)