### PR TITLE
Version note for new Brim Flow Ratio feature

### DIFF
--- a/print_settings/others/others_settings_brim.md
+++ b/print_settings/others/others_settings_brim.md
@@ -121,6 +121,10 @@ The actual brim [flow](quality_settings_wall_and_surfaces#surface-flow-ratio) us
 > [!NOTE]
 > The resulting value will not be affected by the [first-layer flow ratio](quality_settings_wall_and_surfaces#surface-flow-ratio).
 
+> [!IMPORTANT]
+> NEW FEATURE: **Brim Flow Ratio**  
+> Available in: Releases greater than **2.3.2** or [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).
+
 ### Brim use EFC outline
 
 [Variable](built_in_placeholders_variables): `brim_use_efc_outline`.  


### PR DESCRIPTION
Add an IMPORTANT note to print_settings/others/others_settings_brim.md introducing the new "Brim Flow Ratio" feature and its availability (releases > 2.3.2 or Nightly builds). The note was inserted above the "Brim use EFC outline" section to inform users about the new option.
