### PR TITLE
Add extrusion role placeholders and G-code docs

### DIFF
--- a/developer_reference/built_in_placeholders_variables.md
+++ b/developer_reference/built_in_placeholders_variables.md
@@ -22,6 +22,7 @@ Built-in placeholder variables exposed by OrcaSlicer when expanding custom G-cod
     - [Toolchange and wipe tower placeholders](#toolchange-and-wipe-tower-placeholders)
     - [Filament start/end placeholders](#filament-startend-placeholders)
     - [Timelapse and wrapping detection](#timelapse-and-wrapping-detection)
+    - [Extrusion roles](#extrusion-roles)
     - [Extrusion role changes](#extrusion-role-changes)
     - [Pause / color change helpers](#pause--color-change-helpers)
 
@@ -261,12 +262,37 @@ All `layer_*` placeholders from the previous section are also available inside `
 | `timelapse_pos_x` / `timelapse_pos_y` | int (mm) | XY coordinates selected for taking the snapshot. Available only inside `timelapse_gcode`. |
 | `has_timelapse_safe_pos` | bool | Indicates whether a safe snapshot position was found. Available in `timelapse_gcode`. |
 
+### Extrusion roles
+
+| Placeholder | Type | Description |
+| --- | --- | --- |
+| `None` | string | Undefined. |
+| `Perimeter` | string | Inner wall. |
+| `ExternalPerimeter` | string | Outer wall. |
+| `OverhangPerimeter` | string | Overhang wall. |
+| `InternalInfill` | string | Sparse infill. |
+| `SolidInfill` | string | Internal solid infill. |
+| `TopSolidInfill` | string | Top surface. |
+| `BottomSurface` | string | Bottom surface. |
+| `Ironing` | string | Ironing. |
+| `BridgeInfill` | string | Bridge. |
+| `InternalBridgeInfill` | string | Internal Bridge. |
+| `GapFill` | string | Gap infill. |
+| `Skirt` | string | Skirt. |
+| `Brim` | string | Brim. |
+| `SupportMaterial` | string | Support. |
+| `SupportMaterialInterface` | string | Support interface. |
+| `SupportTransition` | string | Support transition. |
+| `WipeTower` | string | Prime tower. |
+| `Custom` | string | Custom. |
+| `Mixed` | string | Multiple. |
+
 ### Extrusion role changes
 
 | Placeholder | Type | Description |
 | --- | --- | --- |
-| `extrusion_role` | string | Name of the extrusion role that the slicer is about to use (Perimeter, ExternalPerimeter, Support, etc.). Available in `change_extrusion_role_gcode`. |
-| `last_extrusion_role` | string | Previous extrusion role before the transition. Available in `change_extrusion_role_gcode`. |
+| `extrusion_role` | string | Name of the [extrusion role](#extrusion-roles) that the slicer is about to use (Perimeter, ExternalPerimeter, Support, etc.). Available in `change_extrusion_role_gcode`. |
+| `last_extrusion_role` | string | Previous [extrusion role](#extrusion-roles) before the transition. Available in `change_extrusion_role_gcode`. |
 
 ### Pause / color change helpers
 

--- a/material_settings/advanced/material_advanced.md
+++ b/material_settings/advanced/material_advanced.md
@@ -9,3 +9,15 @@ These settings allow you to define custom G-code commands that will be executed 
 ## Filament end G-code
 
 These settings allow you to define custom G-code commands that will be executed at the start and end of a print using a specific material. This can be useful for priming the nozzle, purging old filament, or performing any other necessary actions before or after printing.
+
+## Change extrusion role G-code
+
+This G-code is inserted when the [extrusion role](built_in_placeholders_variables#extrusion-roles) is changed.  
+This is the material section of the feature "Change Extrusion Role G-code" that is also available in the [Process settings](others_settings_g_code_output#change-extrusion-role-g-code) and [Printer settings](printer_machine_gcode#change-extrusion-role-g-code).
+
+> [!TIP]
+> Read the [Printer settings](printer_machine_gcode#change-extrusion-role-g-code) for more details and examples.
+
+> [!IMPORTANT]
+> NEW FEATURE: **Material Change Extrusion Role G-code**  
+> Available in: Releases greater than **2.3.2** or [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).

--- a/print_settings/others/others_settings_g_code_output.md
+++ b/print_settings/others/others_settings_g_code_output.md
@@ -8,6 +8,7 @@ These settings control how G-code is generated and formatted. They impact readab
 - [Label Objects](#label-objects)
 - [Exclude Objects](#exclude-objects)
 - [Filename Format](#filename-format)
+- [Change extrusion role G-code](#change-extrusion-role-g-code)
 
 ## Reduce Infill Retraction
 
@@ -55,3 +56,15 @@ Can be used to generate filenames like `OrcaCube_PLA_1h15m.gcode`.
 
 > [!TIP]
 > Check [Naming Built in placeholders variables](built_in_placeholders_variables#filename-templates) for available tokens and their meanings.
+
+## Change extrusion role G-code
+
+This G-code is inserted when the [extrusion role](built_in_placeholders_variables#extrusion-roles) is changed.  
+This is the process section of the feature "Change Extrusion Role G-code" that is also available in the [Material settings](material_advanced#change-extrusion-role-g-code) and [Printer settings](printer_machine_gcode#change-extrusion-role-g-code).
+
+> [!TIP]
+> Read the [Printer settings](printer_machine_gcode#change-extrusion-role-g-code) for more details and examples.
+
+> [!IMPORTANT]
+> NEW FEATURE: **Process Change Extrusion Role G-code**  
+> Available in: Releases greater than **2.3.2** or [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds).

--- a/printer_settings/machine gcode/printer_machine_gcode.md
+++ b/printer_settings/machine gcode/printer_machine_gcode.md
@@ -95,7 +95,8 @@ This G-code is inserted when filament is changed, including T commands to trigge
 
 ## Change extrusion role G-code
 
-This G-code is inserted when the extrusion role is changed.
+This G-code is inserted when the [extrusion role](built_in_placeholders_variables#extrusion-roles) is changed.
+This is the Machine section of the feature "Change Extrusion Role G-code" that is also available in the [Material settings](material_advanced#change-extrusion-role-g-code) and [Process settings](others_settings_g_code_output#change-extrusion-role-g-code).
 
 Example G-codes:
 


### PR DESCRIPTION
Document extrusion roles and the new "Change extrusion role" G-code feature. Added an "Extrusion roles" table to developer_reference/built_in_placeholders_variables.md and updated the extrusion_role/last_extrusion_role entries to link to it. Added Change extrusion role G-code sections to material_settings/advanced, print_settings/others, and printer_settings/machine gcode pages with cross-links, tips, and a note about availability (>= 2.3.2 or nightly builds).