### PR TITLE
Correct filament_diameter formula

### DIFF
--- a/printer_settings/basic information/printer_basic_information_advanced.md
+++ b/printer_settings/basic information/printer_basic_information_advanced.md
@@ -41,7 +41,7 @@ Shape, material and density of an individual pellet will determine the packing d
 We are translating the pellet_flow_coefficient into filament_diameter so that everything works just like it does already with very minor adjustments.
 
 $$
-\text{filament\_diameter} = \sqrt{\frac{4 \times \text{pellet\_flow\_coefficient}}{\pi}}
+\text{filament\_diameter} = \sqrt{\frac{4}{\text{pellet\_flow\_coefficient} \cdot \pi}}
 $$
 
 sqrt just makes the relationship between flow_coefficient and volume linear.


### PR DESCRIPTION
Fix #220 
Update formula in printer_settings/basic information/printer_basic_information_advanced.md to compute filament_diameter as sqrt(4 / (pellet_flow_coefficient · π)) instead of sqrt(4 * pellet_flow_coefficient / π). This fixes the math so diameter scales inversely with pellet_flow_coefficient and preserves the intended linear relationship between flow coefficient and volume.

This was like this from the original commit https://github.com/OrcaSlicer/OrcaSlicer/commit/8ccf0edbc23ea19dfe478512c43be00bb4b61a6c#diff-1b86379cc862fb648492f4b29a745f5b14ce8943aa774f7de8108279275301dd