### PR TITLE
Document Surface / outer wall override filament settings

### DIFF
--- a/print_settings/multimaterial/multimaterial_settings_filament_for_features.md
+++ b/print_settings/multimaterial/multimaterial_settings_filament_for_features.md
@@ -1,6 +1,6 @@
 # Filament for Features
 
-These settings allow you to specify which extruder to use for different features of the print, such as walls, infill, and wipe tower.
+These options are available for multi-material printers (multi-extruder and single-extruder multi-material setups such as AMS, CFS, Mosaic).
 
 <div class="orca-video-embed">
   <a class="orca-video-poster-link" href="https://www.youtube.com/watch?v=hcuQw55OzjU" aria-label="Watch filament for features video">
@@ -18,45 +18,42 @@ Filament to print outer walls.
 This can also be used to use a translucent filament for outer walls to achieve a frosted glass effect.  
 When using a [mixed nozzle size setup](mixed_nozzle_sizes), it's recommended to use the smaller nozzle for outer walls to achieve better surface quality and detail.
 
-## Inner Walls
+## Surface / outer wall override
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `inner_wall_filament_id`.  
-Filament to print inner walls.  
-When using a [mixed nozzle size setup](mixed_nozzle_sizes), you can use a larger nozzle for inner walls to speed up printing while maintaining good layer adhesion.
+[Mode](option_mode): `Simple`.  
+[Variable](built_in_placeholders_variables): `surface_wall_override_filament`.  
+Filament for the outermost N perimeter loops and/or the top/bottom external solid surfaces. Set to `0` (default) to disable the override — all walls and surfaces then use the regular [Walls](#walls) filament.
 
-## Sparse Infill
+Useful when you want a cosmetic or structural contrast between the visible exterior of a print and its interior without per-volume painting. Common uses:
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `sparse_infill_filament_id`.  
-Filament to print internal sparse infill.  
-When using a [mixed nozzle size setup](mixed_nozzle_sizes), you can use a larger nozzle for infill to speed up printing while maintaining good layer adhesion.
+- A coloured outer shell over a different infill filament.
+- Embedded text or logos in a contrasting filament on the top surface.
+- A higher-strength outer skin over a different inner material.
 
-## Internal Solid Infill
+The override stacks on top of per-volume / paint extruder assignments: the painted extruder becomes the *base* filament for the volume, while the outermost N loops (and/or surfaces, depending on [Apply to](#apply-to)) still take the override filament.
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `internal_solid_filament_id`.  
-Filament to print internal solid infill.
-When using a [mixed nozzle size setup](mixed_nozzle_sizes), you can use a larger nozzle for internal solid infill to speed up printing while maintaining good layer adhesion.
+When the override filament belongs to a different polymer family than [Walls](#walls), a warning is shown — cross-polymer-family layer adhesion may be poor.
 
-## Top Surface
+**Trade-off:** the override introduces extra toolchanges per island (one when entering each top/bottom surface, plus per-loop changes when applied to walls and the wall sequence isn't outer-first/last). This increases [wipe tower](multimaterial_settings_prime_tower) volume and total print time. Pick the narrowest [Apply to](#apply-to) value that meets your need.
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `top_surface_filament_id`.  
-Filament to print top surfaces.  
-It's recommended to use the same filament for top surfaces as for outer walls to achieve a consistent appearance.  
-When using a [mixed nozzle size setup](mixed_nozzle_sizes), it's recommended to use the smaller nozzle for top surfaces to achieve better surface quality and detail.
+## Outer wall count
 
-## Bottom Surface
+[Mode](option_mode): `Simple`.  
+[Variable](built_in_placeholders_variables): `outer_wall_count`.  
+Number of outermost perimeter loops (counted from the outside in) that use the [Surface / outer wall override](#surface--outer-wall-override) filament. Only meaningful when the override filament is set and [Apply to](#apply-to) includes `Walls`. Default is `1` — only the outermost loop is overridden.
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `bottom_surface_filament_id`.  
-Filament to print bottom surfaces.  
-This can be used to use a different filament for the bottom layer, such as a more adhesive filament to improve bed adhesion.  
-When using a [mixed nozzle size setup](mixed_nozzle_sizes), you can use a larger nozzle for bottom surfaces to speed up printing while maintaining good layer adhesion.
+## Apply to
 
-## Wipe Tower
+[Mode](option_mode): `Simple`.  
+[Variable](built_in_placeholders_variables): `surface_wall_override_filament_target`.  
+Controls *where* the [Surface / outer wall override](#surface--outer-wall-override) filament is applied:
 
-[Mode](option_mode): `Advanced`.  
-[Variable](built_in_placeholders_variables): `wipe_tower_filament`.  
-The extruder to use when printing perimeter of the wipe tower. Set to 0 to use the one that is available (non-soluble would be preferred).
+- **`Walls`** — outermost N perimeter loops only.
+- **`Surfaces`** — top and bottom external solid surfaces only (including the ironing pass over them); walls keep using the regular [Walls](#walls) filament.
+- **`Both`** *(default)* — walls **and** top/bottom surfaces.
+
+`Surfaces` and `Both` add extra toolchanges per layer, which increases wipe-tower volume noticeably. Pick `Walls` if you only need contrasting perimeters with minimal wipe-tower overhead.
+
+Only takes effect when [Surface / outer wall override](#surface--outer-wall-override) is non-zero.
+
+## Infill

--- a/print_settings/multimaterial/multimaterial_settings_filament_for_features.md
+++ b/print_settings/multimaterial/multimaterial_settings_filament_for_features.md
@@ -22,7 +22,12 @@ When using a [mixed nozzle size setup](mixed_nozzle_sizes), it's recommended to 
 
 [Mode](option_mode): `Simple`.  
 [Variable](built_in_placeholders_variables): `surface_wall_override_filament`.  
-Filament for the outermost N perimeter loops and/or the top/bottom external solid surfaces. Set to `0` (default) to disable the override — all walls and surfaces then use the regular [Walls](#walls) filament.
+
+> [!IMPORTANT]
+> NEW FEATURE: **Surface / outer wall override filament**  
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+
+Filament for the outermost N perimeter loops and/or the top/bottom external solid surfaces. Set to `0` (default) to disable the override — all walls and surfaces then use the regular [Outer Walls](#outer-walls) filament.
 
 Useful when you want a cosmetic or structural contrast between the visible exterior of a print and its interior without per-volume painting. Common uses:
 
@@ -40,12 +45,22 @@ When the override filament belongs to a different polymer family than [Walls](#w
 
 [Mode](option_mode): `Simple`.  
 [Variable](built_in_placeholders_variables): `outer_wall_count`.  
+
+> [!IMPORTANT]
+> NEW FEATURE: **Outer wall count**  
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+
 Number of outermost perimeter loops (counted from the outside in) that use the [Surface / outer wall override](#surface--outer-wall-override) filament. Only meaningful when the override filament is set and [Apply to](#apply-to) includes `Walls`. Default is `1` — only the outermost loop is overridden.
 
 ## Apply to
 
 [Mode](option_mode): `Simple`.  
 [Variable](built_in_placeholders_variables): `surface_wall_override_filament_target`.  
+
+> [!IMPORTANT]
+> NEW FEATURE: **Surface / outer wall override target**  
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+
 Controls *where* the [Surface / outer wall override](#surface--outer-wall-override) filament is applied:
 
 - **`Walls`** — outermost N perimeter loops only.


### PR DESCRIPTION
## Summary

Documents the three new "Filament for Features" settings introduced in [OrcaSlicer PR #13567](https://github.com/OrcaSlicer/OrcaSlicer/pull/13567):

- **`surface_wall_override_filament`** — filament for the outermost N perimeter loops and/or top/bottom external solid surfaces.
- **`outer_wall_count`** — how many outermost loops the override applies to.
- **`surface_wall_override_filament_target`** ("Apply to") — scope: `Walls` / `Surfaces` / `Both` (default `Both`).

Added under `print_settings/multimaterial/multimaterial_settings_filament_for_features.md`, between the existing `Walls` and `Infill` entries.

## Other change

The page intro previously said *"This option is available only for Multi-Extruder printers."* — but the existing settings on the page (`wall_filament`, `sparse_infill_filament`, etc.) also apply to single-extruder multi-material setups (AMS / CFS / Mosaic), and the new override settings work there too. Updated the intro to reflect both topologies.

## Notes

- No new pages added, so the auto-generated navigation should pick up the new sections without changes to `generate_nav.py` or `mkdocs.yml`.
- This PR is gated on the OrcaSlicer code PR merging first — until then the documented variables won't exist in the slicer.
