### PR TITLE
[codex] Fix GitHub wiki calibration video section

### DIFF
--- a/calibration/calibration_guide.md
+++ b/calibration/calibration_guide.md
@@ -11,34 +11,16 @@ To access the calibration features, you can find them in the **Calibration** sec
 > [!IMPORTANT]
 > After completing the calibration process, remember to create a new project in order to exit the calibration mode.
 
-!!! recommended "Recommended: Watch this first for a detailed overview"
-    <div class="orca-video-embed">
-      <a
-        class="orca-video-poster-link"
-        href="https://www.youtube.com/watch?v=gVU5If1VsAM"
-        data-embed-src="https://www.youtube.com/embed/gVU5If1VsAM?autoplay=1&amp;rel=0"
-        aria-label="Play Filament Calibration Masterclass video by Factorian Designs">
-        <img src="../images/video/factorian-calibration-029.png" alt="Filament Calibration Masterclass video preview at 0:29">
-      </a>
-    </div>
-    <script>
-      document.querySelectorAll(".orca-video-poster-link[data-embed-src]").forEach(function(link) {
-        if (link.dataset.videoReady) return;
-        link.dataset.videoReady = "true";
-        link.addEventListener("click", function(event) {
-          event.preventDefault();
-          var iframe = document.createElement("iframe");
-          iframe.src = link.dataset.embedSrc;
-          iframe.title = "Filament Calibration Masterclass - 95% do it wrong! by Factorian Designs";
-          iframe.loading = "lazy";
-          iframe.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
-          iframe.allowFullscreen = true;
-          link.parentElement.replaceChildren(iframe);
-        });
-      });
-    </script>
-
-    <span class="orca-video-credit">Video by <strong>Factorian Designs</strong>, with consent.</span>
+> [!TIP]
+> <strong class="orca-video-title">Recommended: Watch this first for a detailed overview</strong>
+>
+> <div class="orca-video-embed">
+>   <a class="orca-video-poster-link" href="https://www.youtube.com/watch?v=gVU5If1VsAM" aria-label="Watch Filament Calibration Masterclass video by Factorian Designs">
+>     <img src="https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/video/factorian-calibration-029.png?raw=true" alt="Filament Calibration Masterclass video preview at 0:29">
+>   </a>
+> </div>
+>
+> <span class="orca-video-credit">Video by <strong>Factorian Designs</strong>, with consent.</span>
 
 The recommended order for calibration is as follows:
 

--- a/calibration/calibration_guide.md
+++ b/calibration/calibration_guide.md
@@ -16,7 +16,7 @@ To access the calibration features, you can find them in the **Calibration** sec
 >
 > <div class="orca-video-embed">
 >   <a class="orca-video-poster-link" href="https://www.youtube.com/watch?v=gVU5If1VsAM" aria-label="Watch Filament Calibration Masterclass video by Factorian Designs">
->     <img src="https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/video/factorian-calibration-029.png?raw=true" alt="Filament Calibration Masterclass video preview at 0:29">
+>     <img alt="Filament Calibration Masterclass video preview at 0:29" src="https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/video/factorian-calibration-029.png?raw=true">
 >   </a>
 > </div>
 >

--- a/calibration/calibration_guide.md
+++ b/calibration/calibration_guide.md
@@ -16,7 +16,7 @@ To access the calibration features, you can find them in the **Calibration** sec
 >
 > <div class="orca-video-embed">
 >   <a class="orca-video-poster-link" href="https://www.youtube.com/watch?v=gVU5If1VsAM" aria-label="Watch Filament Calibration Masterclass video by Factorian Designs">
->     <img alt="Filament Calibration Masterclass video preview at 0:29" src="https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/video/factorian-calibration-029.png?raw=true">
+>     <img alt="factorian-calibration-029" src="https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/video/factorian-calibration-029.png?raw=true">
 >   </a>
 > </div>
 >

--- a/web_extras/extra.css
+++ b/web_extras/extra.css
@@ -294,6 +294,12 @@ img[height="200"] { /* Calibrations guide preview */
     background-color: #43a04708;
 }
 
+.md-typeset .admonition.tip:has(.orca-video-poster-link),
+.md-typeset details.tip:has(.orca-video-poster-link) {
+    border-color: #43a047;
+    background-color: #43a04708;
+}
+
 .md-typeset .admonition.recommended .admonition-title,
 .md-typeset details.recommended summary{
     color: #43a047;
@@ -304,6 +310,40 @@ img[height="200"] { /* Calibrations guide preview */
     background-color: #43a047;
     -webkit-mask-image: var(--md-admonition-icon--recommended);
     mask-image: var(--md-admonition-icon--recommended);
+}
+
+.md-typeset .admonition.tip:has(.orca-video-poster-link) .admonition-title,
+.md-typeset details.tip:has(.orca-video-poster-link) summary {
+    display: none;
+}
+
+.md-typeset .admonition.tip:has(.orca-video-poster-link)>p:has(.orca-video-title),
+.md-typeset details.tip:has(.orca-video-poster-link)>p:has(.orca-video-title) {
+    margin: 0;
+}
+
+.md-typeset .orca-video-title {
+    align-items: center;
+    color: #43a047;
+    display: flex;
+    font-weight: 700;
+    gap: .6rem;
+    margin: .2rem 0 .8rem;
+}
+
+.md-typeset .orca-video-title:before {
+    background-color: #43a047;
+    content: "";
+    display: inline-block;
+    flex: 0 0 1.2em;
+    height: 1.2em;
+    -webkit-mask-image: var(--md-admonition-icon--recommended);
+    mask-image: var(--md-admonition-icon--recommended);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    width: 1.2em;
 }
 
 .md-typeset .admonition.danger,
@@ -324,16 +364,10 @@ img[height="200"] { /* Calibrations guide preview */
     width: 100%;
 }
 
-.md-typeset .orca-video-embed iframe,
 .md-typeset .orca-video-poster-link,
 .md-typeset .orca-video-poster-link img {
     height: 100%;
     width: 100%;
-}
-
-.md-typeset .orca-video-embed iframe {
-    border: 0;
-    display: block;
 }
 
 .md-typeset .orca-video-poster-link {


### PR DESCRIPTION
## Summary
- Replaces the calibration video section's MkDocs-only admonition and inline script with GitHub Wiki-safe alert Markdown.
- Keeps the 0:29 preview image linked to the YouTube video and retains the Factorian Designs consent credit.
- Retargets the local HTML styling only for this video alert so the generated OrcaSlicer HTML wiki still reads as the custom Recommended section.

## Validation
- Rendered the updated section through GitHub's Markdown API with the OrcaSlicer context and confirmed it produces a GitHub alert, linked preview image, and no raw `!!! recommended`, `data-embed-src`, or `<script>` output.
- Ran `git diff --check`.
- Ran `./build.sh` successfully; it completed with the repository's existing unrelated documentation warnings about missing anchors/assets.
