### PR TITLE
docs(placeholders): document the template expression language

### DIFF
--- a/developer_reference/built_in_placeholders_variables.md
+++ b/developer_reference/built_in_placeholders_variables.md
@@ -60,6 +60,7 @@ The following functions are available:
 | `random(a, b)` | A random number between `a` and `b`. |
 | `interpolate_table(x, (x0, y0), (x1, y1), ...)` | Piecewise-linear interpolation of `x` through the given points. |
 | `one_of(value, a, b, ...)` | True when `value` matches one of the listed entries; entries may be `/regex/` patterns. |
+| `regex_replace(text, /pattern/, replacement)` | Replace every match of `/pattern/` in `text` with `replacement`, which may reference capture groups (`$1`, `$2`, ...). `{regex_replace(first_object_name, /\.[^.]*$/, "")}` strips a file extension. |
 | `size(vec)`, `empty(vec)` | Length of a vector option, and whether it is empty. |
 
 Expressions can also branch. `{if}` / `{elsif}` / `{else}` / `{endif}` chooses between values, so `{if layer_num == 1}first{else}later{endif}` selects text by layer.

--- a/developer_reference/built_in_placeholders_variables.md
+++ b/developer_reference/built_in_placeholders_variables.md
@@ -60,7 +60,7 @@ The following functions are available:
 | `random(a, b)` | A random number between `a` and `b`. |
 | `interpolate_table(x, (x0, y0), (x1, y1), ...)` | Piecewise-linear interpolation of `x` through the given points. |
 | `one_of(value, a, b, ...)` | True when `value` matches one of the listed entries; entries may be `/regex/` patterns. |
-| `regex_replace(text, /pattern/, replacement)` | Replace every match of `/pattern/` in `text` with `replacement`, which may reference capture groups (`$1`, `$2`, ...). `{regex_replace(first_object_name, /\.[^.]*$/, "")}` strips a file extension. |
+| `regex_replace(text, /pattern/, replacement)` | Replace every match of `/pattern/` in `text` with `replacement`, which may reference capture groups (`$1`, `$2`, ...). |
 | `size(vec)`, `empty(vec)` | Length of a vector option, and whether it is empty. |
 
 Expressions can also branch. `{if}` / `{elsif}` / `{else}` / `{endif}` chooses between values, so `{if layer_num == 1}first{else}later{endif}` selects text by layer.

--- a/developer_reference/built_in_placeholders_variables.md
+++ b/developer_reference/built_in_placeholders_variables.md
@@ -3,7 +3,7 @@
 Built-in placeholder variables exposed by OrcaSlicer when expanding custom G-code snippets and template expressions.
 
 - [Conventions](#conventions)
-    - [Functions](#functions)
+    - [Expressions and functions](#expressions-and-functions)
 - [Global Slicing State](#global-slicing-state)
     - [Read Only](#read-only)
     - [Read Write](#read-write)
@@ -35,13 +35,38 @@ Built-in placeholder variables exposed by OrcaSlicer when expanding custom G-cod
 - `layer_num` is one-based (first layer is `1`). All other indices use zero-based numbering.
 - Every print/filament/printer setting is also available under its config key. Hover the label in the UI to see the key or check the Variable in the Wiki description. The tables below focus on additional runtime placeholders.
 
-### Functions
+### Expressions and functions
 
-Basic math operators (`+`, `-`, `*`, `/`) and parentheses are supported for numeric placeholders, allowing you to do simple calculations. For example, `{used_filament/1000}m` converts filament usage to meters.
+Template expressions inside `{ }` can be computed, not just substituted, using a small built-in expression language. Parentheses group sub-expressions.
 
-C++ functions can be used as long as they are not from a library to be included, such as `cmath`.
+The following operators are available:
 
-- Rounding: can be done using `int()`, for example `{int(total_weight*10) / 10.0}g`. `round()`: **cannot** be used because it is a function from the cmath library.
+- Arithmetic `+`, `-`, `*`, `/`, `%` (modulo). For example `{used_filament / 1000}` converts filament usage to metres.
+- Comparison `==`, `!=`, `<`, `>`, `<=`, `>=`, producing a boolean.
+- Logical `and` / `&&`, `or` / `||`, `not` / `!`.
+- Ternary `condition ? a : b`.
+- String concatenation with `+`, for example `{"v" + layer_num}`.
+- Regular-expression match `text =~ /pattern/` (true when `text` matches) and its negation `!~`, for example `{if printer_notes =~ /.*BAMBU.*/}bambu{endif}`.
+
+The following functions are available:
+
+| Function | Description |
+| --- | --- |
+| `int(x)` | Truncate toward zero. `{int(13.9)}` is `13`. |
+| `round(x)`, `floor(x)`, `ceil(x)` | Nearest, lower, or higher integer. |
+| `min(a, b)`, `max(a, b)` | Smaller or larger of two numbers. |
+| `digits(value, width [, decimals])` | Number right-justified in `width` characters, optionally with a fixed number of decimals. |
+| `zdigits(value, width [, decimals])` | Like `digits`, padded with leading zeros. `{zdigits(5, 4)}` is `0005`. |
+| `random(a, b)` | A random number between `a` and `b`. |
+| `interpolate_table(x, (x0, y0), (x1, y1), ...)` | Piecewise-linear interpolation of `x` through the given points. |
+| `one_of(value, a, b, ...)` | True when `value` matches one of the listed entries; entries may be `/regex/` patterns. |
+| `size(vec)`, `empty(vec)` | Length of a vector option, and whether it is empty. |
+
+Expressions can also branch. `{if}` / `{elsif}` / `{else}` / `{endif}` chooses between values, so `{if layer_num == 1}first{else}later{endif}` selects text by layer.
+
+Intermediate values can be stored in variables. `{local name = "part"}{name}` defines one and reuses it. A `{local}` value is scoped to the current template, while a `{global}` value stays available to the other templates evaluated during the same print.
+
+Vector options are indexed with `[i]`, for example `{nozzle_temperature[0]}`.
 
 ## Global Slicing State
 


### PR DESCRIPTION
The **Functions** section of the built-in placeholders page was inaccurate and thin. It claimed `round()` cannot be used ("because it is a function from the cmath library") and described the syntax as calling C++ functions. Neither is true: the template field is evaluated by a small built-in expression language with its own fixed set of operators and functions, and `round()` / `floor()` / `ceil()` are among them.

This rewrites the section to document what actually exists:
- operators (arithmetic including `%`, comparison, logical, ternary, string `+`, regex match `=~` / `!~`)
- functions (`int`, `round` / `floor` / `ceil`, `min` / `max`, `digits` / `zdigits`, `random`, `interpolate_table`, `one_of`, `regex_replace`, `size` / `empty`)
- conditionals (`{if}` / `{elsif}` / `{else}` / `{endif}`) and variables (`{local}` / `{global}`)

`regex_replace()` is the string-transform function added in OrcaSlicer/OrcaSlicer#14650 (merged).

The section heading changed (`Functions` to `Expressions and functions`), so the page's own table of contents is updated to match. No other wiki page links to the old `#functions` anchor.

Documentation only, no behaviour change. Verified against the parser grammar and the `test_placeholder_parser.cpp` unit tests.
