### PR TITLE
Document outer-only and radius brim ear changes

### DIFF
--- a/print_prepare/prepare_brim_ears_painting.md
+++ b/print_prepare/prepare_brim_ears_painting.md
@@ -1,11 +1,17 @@
 # Brim ears Painting
 
 This painting tool allows you to paint brim ears on the base of your 3D model to improve bed adhesion during printing.  
-It also includes an Auto-generate points feature that automatically detects and applies brim ears to suitable areas of the model.
+It also includes an Auto-generate feature that automatically detects and applies brim ears to suitable areas of the model.
+
+> [!IMPORTANT]
+> NEW FEATURE: **The Head diameter control is renamed Brim ear radius and now accepts values from 0.1 mm to 100 mm.**  
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
 
 ## Parameters
 
-- **Head diameter**: Sets the diameter of the brim ear heads.
-- **Max angle**: Defines the maximum angle at which brim ears will be applied with Auto-generate points.
-- **Detection Radius**: Decrease to increase Brim Ears quantity. Sets the radius for detecting areas (using [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm)) to apply brim ears with Auto-generate points.
+- **Brim ear radius**: Sets the radius of brim ears placed manually or with Auto-generate. Values from 0.1 mm to 100 mm are supported.
+- **Max angle**: Defines the maximum angle at which brim ears will be applied with Auto-generate.
+- **Detection radius**: Lower values can detect more candidate positions. Sets the radius for detecting areas (using the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm)) where Auto-generate may place brim ears.
 - **Section view**: Adjusts the section view height to better visualize brim ear placement.
+
+When **Brim type** is set to **Painted**, enable [Brim ears outer only](others_settings_brim#brim-ears-outer-only) in **Process > Others > Brim** to exclude painted ears placed in holes or other enclosed sections when slicing.

--- a/print_prepare/prepare_brim_ears_painting.md
+++ b/print_prepare/prepare_brim_ears_painting.md
@@ -9,7 +9,8 @@ It also includes an Auto-generate feature that automatically detects and applies
 
 ## Parameters
 
-- **Brim ear radius**: Sets the radius of brim ears placed manually or with Auto-generate. Values from 0.1 mm to 100 mm are supported.
+- **Head diameter** *(OrcaSlicer 2.4.2)*: Controls the nominal diameter of painted brim ears. The value is limited to 20 mm. Because of a sizing issue in 2.4.2, the sliced ear may not exactly match the entered diameter.
+- **Brim ear radius** *(Nightly builds and releases greater than 2.4.2)*: Sets the radius of brim ears placed manually or with Auto-generate. Values from 0.1 mm to 100 mm are supported.
 - **Max angle**: Defines the maximum angle at which brim ears will be applied with Auto-generate.
 - **Detection radius**: Lower values can detect more candidate positions. Sets the radius for detecting areas (using the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm)) where Auto-generate may place brim ears.
 - **Section view**: Adjusts the section view height to better visualize brim ear placement.

--- a/print_prepare/prepare_brim_ears_painting.md
+++ b/print_prepare/prepare_brim_ears_painting.md
@@ -15,4 +15,4 @@ It also includes an Auto-generate feature that automatically detects and applies
 - **Detection radius**: Lower values can detect more candidate positions. Sets the radius for detecting areas (using the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm)) where Auto-generate may place brim ears.
 - **Section view**: Adjusts the section view height to better visualize brim ear placement.
 
-When **Brim type** is set to **Painted**, enable [Brim ears outer only](others_settings_brim#brim-ears-outer-only) in **Process > Others > Brim** to exclude painted ears placed in holes or other enclosed sections when slicing.
+When **Brim type** is set to **Painted**, enable [Brim ears outer only](others_settings_brim#brim-ears-outer-only) *(Nightly builds and releases greater than 2.4.2)* in **Process > Others > Brim** to exclude painted ears placed in holes or other enclosed sections when slicing.

--- a/print_prepare/prepare_brim_ears_painting.md
+++ b/print_prepare/prepare_brim_ears_painting.md
@@ -9,10 +9,9 @@ It also includes an Auto-generate feature that automatically detects and applies
 
 ## Parameters
 
-- **Head diameter** *(OrcaSlicer 2.4.2)*: Controls the nominal diameter of painted brim ears. The value is limited to 20 mm. Because of a sizing issue in 2.4.2, the sliced ear may not exactly match the entered diameter.
-- **Brim ear radius** *(Nightly builds and releases greater than 2.4.2)*: Sets the radius of brim ears placed manually or with Auto-generate. Values from 0.1 mm to 100 mm are supported.
+- **Brim ear radius**: Sets the radius of brim ears placed manually or with Auto-generate. Values from 0.1 mm to 100 mm are supported.
 - **Max angle**: Defines the maximum angle at which brim ears will be applied with Auto-generate.
 - **Detection radius**: Lower values can detect more candidate positions. Sets the radius for detecting areas (using the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm)) where Auto-generate may place brim ears.
 - **Section view**: Adjusts the section view height to better visualize brim ear placement.
 
-When **Brim type** is set to **Painted**, enable [Brim ears outer only](others_settings_brim#brim-ears-outer-only) *(Nightly builds and releases greater than 2.4.2)* in **Process > Others > Brim** to exclude painted ears placed in holes or other enclosed sections when slicing.
+When **Brim type** is set to **Painted**, enable [Brim ears outer only](others_settings_brim#brim-ears-outer-only) in **Process > Others > Brim** to exclude painted ears placed in holes or other enclosed sections when slicing.

--- a/print_settings/others/others_settings_brim.md
+++ b/print_settings/others/others_settings_brim.md
@@ -120,7 +120,7 @@ This setting is available for both the **Mouse Ears** and **Painted** brim types
 Distance between the model and the outermost brim line.  
 Increasing this value widens the brim, which can improve adhesion but increases material usage.
 
-When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** and its value sets the radius of each automatically generated ear. When **Brim type** is set to **Painted**, the size of brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
+When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** *(Nightly builds and releases greater than 2.4.2)*. Its value sets the radius of each automatically generated ear. When **Brim type** is set to **Painted**, the size of brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
 
 ## Brim-Object Gap
 

--- a/print_settings/others/others_settings_brim.md
+++ b/print_settings/others/others_settings_brim.md
@@ -120,7 +120,7 @@ This setting is available for both the **Mouse Ears** and **Painted** brim types
 Distance between the model and the outermost brim line.  
 Increasing this value widens the brim, which can improve adhesion but increases material usage.
 
-When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** and its value sets the radius of each automatically generated ear. The size of painted brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
+When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** and its value sets the radius of each automatically generated ear. When **Brim type** is set to **Painted**, the size of brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
 
 ## Brim-Object Gap
 

--- a/print_settings/others/others_settings_brim.md
+++ b/print_settings/others/others_settings_brim.md
@@ -13,6 +13,7 @@ Brim is a flat layer printed around a model's base to improve adhesion to the pr
     - [Mouse Ears](#mouse-ears)
         - [Ear max angle](#ear-max-angle)
         - [Ear detection radius](#ear-detection-radius)
+- [Brim ears outer only](#brim-ears-outer-only)
 - [Width](#width)
 - [Brim-Object Gap](#brim-object-gap)
     - [Brim Flow Ratio](#brim-flow-ratio)
@@ -102,12 +103,24 @@ The geometry will be decimated before detecting sharp angles.
 This parameter indicates the minimum length of the deviation for the decimation.  
 0 to deactivate.
 
+## Brim ears outer only
+
+> [!IMPORTANT]
+> NEW FEATURE: **Limit automatic and painted brim ears to outer contours**  
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+
+When enabled, brim ears are generated only on the model's outer contour. Ears that would otherwise be placed in holes or other enclosed sections are excluded.
+
+This setting is available for both the **Mouse Ears** and **Painted** brim types. In Mouse Ears mode, it filters automatically detected ears. In Painted mode, it filters painted ears when the model is sliced.
+
 ## Width
 
 [Mode](option_mode): `Simple`.  
 [Variable](built_in_placeholders_variables): `brim_width`.  
 Distance between the model and the outermost brim line.  
 Increasing this value widens the brim, which can improve adhesion but increases material usage.
+
+When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** and its value sets the radius of each automatically generated ear. The size of painted brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
 
 ## Brim-Object Gap
 


### PR DESCRIPTION
## What changed

- document **Brim ears outer only** for both automatic Mouse Ears and Painted brim modes
- explain the version-delimited **Brim width** to **Brim ear radius** label change in Mouse Ears mode
- document **Head diameter** for OrcaSlicer 2.4.2 alongside **Brim ear radius** for Nightly builds and releases greater than 2.4.2
- document the 2.4.2 painted-ear sizing issue and the corrected 0.1 mm to 100 mm radius range
- add temporary availability notices for Nightly builds and releases greater than 2.4.2

## Why

OrcaSlicer/OrcaSlicer#15015 added these controls and behavior after the 2.4.2 stable release. The wiki currently omits the outer-only option and describes only the older painted-ear control. Version-delimited wording keeps the page useful for both current stable and Nightly users during the transition.

## User impact

OrcaSlicer 2.4.2 users can still identify and understand **Head diameter**, while Nightly users can identify the new radius controls and restrict both automatic and painted ears to outer contours.

## Validation

- limited the change to the two existing brim documentation pages
- updated the Brim page table of contents for the new section
- checked the new internal heading anchor and cross-page link
- followed the wiki's temporary new-feature notice format