### PR TITLE
Fix filament profile name format

### DIFF
--- a/guides/how_to_create_profiles.md
+++ b/guides/how_to_create_profiles.md
@@ -22,7 +22,7 @@ In this case:
 - Vendor profile: `Orca 3D`
 - Printer profile: `Orca 3D Fuse1`
 - Printer variant profile: `Orca 3D Fuse1 0.4 nozzle`
-- Filament profile: `Generic PLA @Orca 3D Fuse1@`
+- Filament profile: `Generic PLA @Orca 3D Fuse1`
 - Process profile: `0.20mm Standard @Orca 3D Fuse1 0.4`
 
 The profile name should be same as the filename without the `.json` extension in principal.


### PR DESCRIPTION
Corrected the filament profile name format by removing the trailing '@' symbol.

It might confuse some people.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

## Related OrcaSlicer PRs

<!--
> Please list any related OrcaSlicer PRs that are associated with this documentation update.
> e.g. https://github.com/OrcaSlicer/OrcaSlicer/pull/[PR_NUMBER]
-->
