### PR TITLE
Fix internal calibration links

### DIFF
--- a/print_settings/quality/quality_settings_precision.md
+++ b/print_settings/quality/quality_settings_precision.md
@@ -76,7 +76,7 @@ Used to compensate external dimensions of the model.
 With this option you can compensate material expansion or shrinkage, which can occur due to various factors such as the type of filament used, temperature fluctuations, or printer calibration issues.
 
 > [!TIP]
-> Follow the [Calibration Guide](https://github.com/OrcaSlicer/OrcaSlicer/wiki/calibration) and [Filament Tolerance Calibration](https://github.com/OrcaSlicer/OrcaSlicer/wiki/tolerance_calib) to determine the correct value for your printer and filament combination.
+> Follow the [Calibration Guide](calibration_guide) and [Filament Tolerance Calibration](tolerance_calib) to determine the correct value for your printer and filament combination.
 
 ### X-Y hole compensation
 


### PR DESCRIPTION
Fix #339
Update the calibration and filament tolerance links in the precision quality settings page to use the wiki's internal page references instead of external GitHub wiki URLs. This keeps the documentation consistent with the repo's internal link rules and prevents broken links in the generated wiki.

Thanks @rgsteele for reporting!!!