### PR TITLE
docs: document compiler caching, and match the presets to build_win.bat

### DIFF
--- a/developer_reference/how_to_build/compiler_caching.md
+++ b/developer_reference/how_to_build/compiler_caching.md
@@ -1,0 +1,124 @@
+# Compiler Caching
+
+A compiler cache keeps the object file each compile produced, stored against a hash of the source, the headers it pulled in and the command line. When those inputs come round again the object is copied back instead of compiled. Rebuilding after a branch switch, a reconfigure, or into a new build directory then costs a fraction of the usual time.
+
+OrcaSlicer supports [ccache](https://ccache.dev/) and [sccache](https://github.com/mozilla/sccache) on Windows and Linux.
+
+- [What It Costs](#what-it-costs)
+- [Windows](#windows)
+- [Linux](#linux)
+- [macOS](#macos)
+- [Cache Size](#cache-size)
+- [Sharing One Cache Between Build Directories](#sharing-one-cache-between-build-directories)
+- [Checking It Works](#checking-it-works)
+
+## What It Costs
+
+Caching is not free, and whether it pays depends on how you work.
+
+A cache only helps when it is asked for something it already holds, so the first build of anything fills it and gains nothing. Both tools also refuse to cache a compile that uses a precompiled header, so enabling a cache means building without one. That makes every compile parse the full header set itself, which roughly doubles a build from scratch.
+
+What you get back is the rebuild. A configuration already in the cache links rather than compiles, so the same work drops from tens of minutes to around a minute, most of which is linking.
+
+That trade suits some habits more than others:
+
+- **Worth it** if you switch branches often, keep more than one build directory, reconfigure regularly, or rebuild the same commit in a different configuration.
+- **Not worth much** if you build one directory, edit a handful of files and rebuild incrementally. Ninja already skips everything you did not touch, and the precompiled header makes the files you did touch compile faster.
+
+## Windows
+
+ccache already ships inside [Strawberry Perl](https://strawberryperl.com/), which the build needs anyway, so `where ccache` usually finds one. If not:
+
+```pwsh
+winget install --id=Ccache.Ccache -e
+```
+
+Then pass `--cache` to [the build script](how_to_build_windows#the-build-script):
+
+```pwsh
+build_win.bat -s -l -x --cache ccache
+```
+
+The value is `ccache`, `sccache` or `off`. It needs `-l -x`, because CMake only runs a compiler launcher under the Ninja and Makefile generators, and ccache refuses a `cl.exe` compile that carries `/Zi`.
+
+`--cache` also turns the precompiled header off, since neither tool caches a compile that uses one.
+
+The build script names the tool it resolved before it starts:
+
+```text
+Precompiled header: off
+Compiler cache: C:/Strawberry/c/bin/ccache.exe
+```
+
+### Visual Studio and VS Code
+
+Neither reads the build script, so the same settings need added to [the preset file](how_to_build_windows#the-preset-file). Four entries in `cacheVariables`:
+
+```json
+"CMAKE_C_COMPILER_LAUNCHER": "ccache",
+"CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+"SLIC3R_PCH": { "type": "BOOL", "value": "OFF" },
+"SLIC3R_RELATIVE_DEBUG_PATHS": { "type": "BOOL", "value": "ON" }
+```
+
+ccache has to be on `PATH` for the IDE process. Because those presets already build into the same directories `build_win.bat` uses, the IDE and the script then reuse each other's work instead of reconfiguring over it.
+
+## Linux
+
+Install ccache from the package manager, for example `apt install ccache` or `pacman -S ccache`.
+
+[`build_linux.sh`](how_to_build_linux) enables caching by itself once a tool is on `PATH`, preferring sccache over ccache. Name the one you want with `CMAKE_CCACHE`:
+
+```bash
+CMAKE_CCACHE=ccache ./build_linux.sh -s
+```
+
+Add `-p` to disable the precompiled header, which the script's own help describes as boosting the ccache hit rate. On Windows `--cache` does this for you; on Linux it stays a separate choice, so a cache without `-p` will refuse most of what it is offered.
+
+## macOS
+
+Not supported. `build_release_macos.sh` has no compiler launcher option, and nothing in the macOS build sets one, so there is nothing to enable.
+
+## Cache Size
+
+Once the cache is full, both tools evict whatever was used least recently, so too small a limit discards builds you still want. ccache defaults to 5 GB and one full build of OrcaSlicer occupies 1 to 2 GB of it, so raise the limit by roughly how many builds you want kept:
+
+```pwsh
+ccache -M 20G
+```
+
+A build here means one configuration of one checkout. Debug and Release count separately, as does the same commit in a second worktree.
+
+- **5 GB**, the default, keeps two or three. Enough while you stay in one configuration.
+- **20 GB** covers several configurations and branches, which suits most work.
+- **50 GB** or more if you keep multiple worktrees, or move between Debug and Release regularly.
+
+## Sharing One Cache Between Build Directories
+
+This part is ccache only; sccache has no equivalent setting.
+
+By default an object records the directory it was compiled in, so a second build directory shares nothing with the first even at the same commit. Two ccache settings and one build option change that.
+
+`ccache --show-config` prints which file it reads. Add:
+
+```text
+base_dir = /path/that/contains/your/checkouts
+hash_dir = false
+```
+
+`base_dir` has to be an ancestor of the sources, the build directories **and** the dependency prefix. If it covers only some of them, ccache rewrites part of each compile line and the rest still differs.
+
+The build option is `SLIC3R_RELATIVE_DEBUG_PATHS`, which records `.` as the compilation directory rather than an absolute path. `--cache` sets it, and the preset entries above set it explicitly. Debugging is unaffected, because the linker writes the absolute source paths into the PDB.
+
+> [!NOTE]
+> Turning this on changes every compile line, so the first build afterwards rebuilds everything and fills the cache again.
+
+## Checking It Works
+
+```pwsh
+ccache -s
+```
+
+`Cacheable calls` is how many compiles ccache saw and `Hits` how many it served without compiling. A first build is mostly misses. Build the same commit into a fresh directory and those files should come back as hits, nearly all of them direct.
+
+`Uncacheable calls` in the hundreds means something is stopping ccache from storing most of what it sees. `ccache -sv` names the reason for each one. A precompiled header still being used is the common cause, and `/Zi` on a `cl.exe` compile is the other.

--- a/developer_reference/how_to_build/how_to_build.md
+++ b/developer_reference/how_to_build/how_to_build.md
@@ -5,6 +5,7 @@ OrcaSlicer builds from source on Windows, macOS, and Linux. Each platform has it
 - [Build on Windows](how_to_build_windows)
 - [Build on macOS](how_to_build_macos)
 - [Build on Linux](how_to_build_linux)
+- [Compiler Caching](compiler_caching)
 
 ## Build Stages
 

--- a/developer_reference/how_to_build/how_to_build_windows.md
+++ b/developer_reference/how_to_build/how_to_build_windows.md
@@ -121,6 +121,7 @@ Use `buildtools` in place of `ide` for the Build Tools without the IDE, and add 
 | `--no-gettext` | Skip regenerating the translations |
 | `-j <n>` | Cap the number of parallel compilers |
 | `-c` | Delete the directories this run would build |
+| `--cache <tool>` | Compile through [a compiler cache](compiler_caching), needs `-l -x` |
 | `-D` | Print every command instead of running it |
 
 Build directories are named for the configuration, compiler and architecture that made them, so changing any of the three configures a new directory instead of reusing one built another way:
@@ -236,7 +237,7 @@ winget install --id=Ninja-build.Ninja -e
 
 ### The Preset File
 
-Visual Studio, VS Code and the command line all read the same CMake preset file. Create `CMakeUserPresets.json` in the repository root:
+Visual Studio, VS Code and `cmake --preset` all read the same CMake preset file. Create `CMakeUserPresets.json` in the repository root:
 
 ```json
 {
@@ -245,18 +246,19 @@ Visual Studio, VS Code and the command line all read the same CMake preset file.
     {
       "name": "x64-clang",
       "displayName": "x64 Clang",
-      "description": "clang-cl and Ninja Multi-Config, built against deps/build-clang",
+      "description": "Matches build_win.bat -s -l -x --tests (build-clang), plus RelWithDebInfo and MinSizeRel in the same directory",
       "generator": "Ninja Multi-Config",
       "binaryDir": "${sourceDir}/build-clang",
       "architecture": { "value": "x64", "strategy": "external" },
       "toolset": { "value": "host=x64", "strategy": "external" },
       "environment": {
-        "CC": "clang-cl",
-        "CXX": "clang-cl",
         "NINJA_STATUS": "[%f/%t %p :: %w / %W] "
       },
       "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
         "CMAKE_CONFIGURATION_TYPES": "Release;RelWithDebInfo;MinSizeRel",
+        "ORCA_TOOLS": { "type": "BOOL", "value": "ON" },
         "BUILD_TESTS": { "type": "BOOL", "value": "ON" }
       },
       "vendor": {
@@ -269,18 +271,18 @@ Visual Studio, VS Code and the command line all read the same CMake preset file.
     {
       "name": "x64-clang-debug",
       "displayName": "x64 Clang Debug",
-      "description": "clang-cl and Ninja, built against deps/build-dbg-clang",
-      "generator": "Ninja",
+      "description": "Matches build_win.bat -s -l -x --tests --config debug (build-dbg-clang)",
+      "generator": "Ninja Multi-Config",
       "binaryDir": "${sourceDir}/build-dbg-clang",
       "architecture": { "value": "x64", "strategy": "external" },
       "toolset": { "value": "host=x64", "strategy": "external" },
       "environment": {
-        "CC": "clang-cl",
-        "CXX": "clang-cl",
         "NINJA_STATUS": "[%f/%t %p :: %w / %W] "
       },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "ORCA_TOOLS": { "type": "BOOL", "value": "ON" },
         "BUILD_TESTS": { "type": "BOOL", "value": "ON" }
       },
       "vendor": {
@@ -295,7 +297,7 @@ Visual Studio, VS Code and the command line all read the same CMake preset file.
     { "name": "x64-clang-release",        "configurePreset": "x64-clang", "configuration": "Release" },
     { "name": "x64-clang-relwithdebinfo", "configurePreset": "x64-clang", "configuration": "RelWithDebInfo" },
     { "name": "x64-clang-minsizerel",     "configurePreset": "x64-clang", "configuration": "MinSizeRel" },
-    { "name": "x64-clang-debug-build",    "configurePreset": "x64-clang-debug" }
+    { "name": "x64-clang-debug-build",    "configurePreset": "x64-clang-debug", "configuration": "Debug" }
   ],
   "testPresets": [
     {
@@ -313,6 +315,7 @@ Visual Studio, VS Code and the command line all read the same CMake preset file.
     {
       "name": "x64-clang-test-debug",
       "configurePreset": "x64-clang-debug",
+      "configuration": "Debug",
       "output": { "outputOnFailure": true }
     }
   ]
@@ -323,10 +326,13 @@ Visual Studio, VS Code and the command line all read the same CMake preset file.
 
 Neither preset sets `CMAKE_PREFIX_PATH`. CMake derives the dependency directory from the **name** of the build directory, so `build-clang` finds `deps\build-clang` and `build-dbg-clang` finds `deps\build-dbg-clang`. Those are the names `build_win.bat -l -x` uses, so the presets and the script share build directories and neither reconfigures what the other built.
 
-Only RelWithDebInfo is compiled with `/Zi`, so switch to it when you need to debug. Release and MinSizeRel produce no symbols to step through.
+All four configurations carry symbols, since `SLIC3R_MSVC_PDB` adds `/Zi` to every MSVC build by default. Optimization is what makes Release and MinSizeRel awkward to step through, with inlined frames and variables the debugger cannot show, so switch to RelWithDebInfo when you need to debug.
 
 > [!TIP]
 > `BUILD_TESTS` is `ON` so the test suites build alongside the application, and the test presets can run them. Set it to `OFF` for slightly faster builds if you do not need them. See [How to Test](how_to_test).
+
+> [!TIP]
+> Four more entries in `cacheVariables` build these presets through a compiler cache, so the IDE and `build_win.bat` reuse each other's work. See [Compiler Caching](compiler_caching).
 
 > [!TIP]
 > On Ninja 1.12 or newer, changing `NINJA_STATUS` to `"[%f/%t %p :: %w / %W] "` adds elapsed time and an ETA to each line:

--- a/home.md
+++ b/home.md
@@ -255,6 +255,7 @@ See the [all releases](releases_index) overview, or jump straight to a version:
     - [Windows](how_to_build_windows)
     - [macOS](how_to_build_macos)
     - [Linux](how_to_build_linux)
+    - [Compiler caching](compiler_caching)
 - [How to run tests](how_to_test)
 - [Preset, PresetBundle and PresetCollection](preset_and_bundle)
 - [Plater, Sidebar, Tab, ComboBox](plater_sidebar_tab_combobox)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,7 @@ nav:
     - "Build on Windows": developer_reference/how_to_build/how_to_build_windows.md
     - "Build on macOS": developer_reference/how_to_build/how_to_build_macos.md
     - "Build on Linux": developer_reference/how_to_build/how_to_build_linux.md
+    - "Compiler Caching": developer_reference/how_to_build/compiler_caching.md
   - "How to Test": developer_reference/how_to_test.md
   - "Application Structure Overview": developer_reference/plater_sidebar_tab_combobox.md
   - "Preset and Bundle": developer_reference/preset_and_bundle.md


### PR DESCRIPTION
# Description

Adds a **Compiler Caching** page and fixes two things on the Windows build page that it depends on.

The new page covers ccache and sccache on Windows and Linux: what caching costs as well as what it saves, how to enable it from `build_win.bat`, from the preset file and from `build_linux.sh`, how large to make the cache, and how to share one between build directories. macOS gets a short section saying it has no support yet, since neither its script nor its CMake path sets a compiler launcher.

The Windows preset file is replaced with one that matches what `build_win.bat -l -x` actually configures, so the IDE and the script share build directories instead of reconfiguring over each other:

* the debug preset generated with plain `Ninja` while the script uses `Ninja Multi-Config`, which swapped the generator underneath `build-dbg-clang`
* `ORCA_TOOLS` was unset, while the script always passes it
* the compiler now comes from `cacheVariables` rather than `CC` and `CXX`

The page also corrects the claim that only RelWithDebInfo carries symbols. `SLIC3R_MSVC_PDB` adds `/Zi` to every MSVC build by default, so what makes Release awkward to step through is optimization, not missing debug info.

No speed figures are quoted. The page describes the trade in both directions and leaves developers to measure their own machines.

## Related OrcaSlicer PRs

* https://github.com/OrcaSlicer/OrcaSlicer/pull/15552
* https://github.com/OrcaSlicer/OrcaSlicer/pull/15573
