### PR TITLE
Change wording from "Releases greater than" to "Releases starting from"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ When documenting a feature that is only in nightly/newer builds, add:
 ```markdown
 > [!IMPORTANT]
 > NEW FEATURE: **Feature short description**
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **<stable version at merge time>**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **<stable version at merge time>**.
 ```
 
 Remove the note once a stable release that includes the feature ships.

--- a/calibration/vfa_calib.md
+++ b/calibration/vfa_calib.md
@@ -13,7 +13,7 @@ The VFA Speed Test in OrcaSlicer helps identify which print speeds trigger MRR a
 
 > [!IMPORTANT]
 > NEW FEATURE: **Nozzle-aware VFA tower with automatic volumetric speed handling**
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 1. Set the VFA test parameters in OrcaSlicer:  
    ![vfa_test_menu](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/vfa/vfa_test_menu.png?raw=true)

--- a/guides/how_to_wiki.md
+++ b/guides/how_to_wiki.md
@@ -241,14 +241,14 @@ When new features or upgrades are merged into the main branch, please add a note
 ```markdown
 > [!IMPORTANT]
 > NEW FEATURE: **Feature short description**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **stable version number at merge time**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **stable version number at merge time**.
 ```
 
 Example:
 
 > [!IMPORTANT]
 > NEW FEATURE: **Inverse Hole Direction**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.0**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.0**.
 
 This notes should be removed after a new stable release is made that includes the new feature.
 

--- a/home.md
+++ b/home.md
@@ -228,7 +228,7 @@ OrcaSlicer can run headless from the command line for automation, batch processi
 
 > [!IMPORTANT]
 > NEW FEATURE: **Python Plugin System**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 - [Getting Started](plugins_getting_started)
 - [Local Plugins](plugins_local)
@@ -241,7 +241,7 @@ OrcaSlicer can run headless from the command line for automation, batch processi
 
 > [!IMPORTANT]
 > NEW FEATURE: **Publish 3MF**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than 2.5.0.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from 2.5.0.
 
 - [What does Publish 3MF do?](publish_3mf)
 - [For creators](publish_3mf_creators)

--- a/material_settings/cooling/material_cooling.md
+++ b/material_settings/cooling/material_cooling.md
@@ -47,7 +47,7 @@ Disabling the fan for the first few layers improves build-plate adhesion and red
 
 > [!IMPORTANT]
 > NEW FEATURE: **First layer fan speed**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Sets an exact fan speed (in %) for the first layer, overriding all other cooling settings.  
 This is useful for protecting 3D-printed toolhead parts (e.g. Voron-style ABS/ASA ducts) from a hot bed: a small amount of airflow cools the ducts down without using full cooling, which may in certain conditions hurt first-layer adhesion. From the second layer onwards, normal cooling resumes.  

--- a/plugins/plugins_getting_started.md
+++ b/plugins/plugins_getting_started.md
@@ -4,7 +4,7 @@ Plugins add extra features to OrcaSlicer. They are managed from the Plugins wind
 
 > [!IMPORTANT]
 > NEW FEATURE: **Python Plugin System**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 - [Local Plugins](plugins_local)
 - [Cloud Plugins](plugins_cloud)

--- a/plugins/plugins_speed_dial.md
+++ b/plugins/plugins_speed_dial.md
@@ -2,7 +2,7 @@
 
 > [!IMPORTANT]
 > NEW FEATURE: **Actions Speed Dial**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 The Actions Speed Dial is a search-first launcher for enabled **Script** plugin capabilities.
 It is available from the **Prepare** tab by pressing **Space**.

--- a/print_prepare/prepare_brim_ears_painting.md
+++ b/print_prepare/prepare_brim_ears_painting.md
@@ -5,7 +5,7 @@ It also includes an Auto-generate feature that automatically detects and applies
 
 > [!IMPORTANT]
 > NEW FEATURE: **The Head diameter control is renamed Brim ear radius and now accepts values from 0.1 mm to 100 mm.**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 ## Parameters
 

--- a/print_settings/multimaterial/multimaterial_settings_advanced.md
+++ b/print_settings/multimaterial/multimaterial_settings_advanced.md
@@ -29,7 +29,7 @@ Generate interlocking beam structure at the locations where different filaments 
 
 > [!IMPORTANT]
 > NEW FEATURE: **Toolchange ordering**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Determines the order of tool changes on each layer:
 

--- a/print_settings/others/others_settings_brim.md
+++ b/print_settings/others/others_settings_brim.md
@@ -118,7 +118,7 @@ This parameter indicates the minimum length of the deviation for the decimation.
 [CLI Example](cli_mode#setting-overrides): `--brim-ears-outer-only=1`.  
 > [!IMPORTANT]
 > NEW FEATURE: **Limit automatic and painted brim ears to outer contours**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 When enabled, brim ears are generated only on the model's outer contour. Ears that would otherwise be placed in holes or other enclosed sections are excluded.
 
@@ -133,7 +133,7 @@ This setting is available for both the **Mouse Ears** and **Painted** brim types
 Distance between the model and the outermost brim line.  
 Increasing this value widens the brim, which can improve adhesion but increases material usage.
 
-When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** *(Nightly builds and releases greater than 2.4.2)*. Its value sets the radius of each automatically generated ear. When **Brim type** is set to **Painted**, the size of brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
+When **Brim type** is set to **Mouse Ears**, this setting is labeled **Brim ear radius** *(Nightly builds and Releases starting from 2.4.2)*. Its value sets the radius of each automatically generated ear. When **Brim type** is set to **Painted**, the size of brim ears is controlled in the [Brim ears Painting tool](prepare_brim_ears_painting).
 
 ## Brim-Object Gap
 

--- a/print_settings/others/others_settings_special_mode.md
+++ b/print_settings/others/others_settings_special_mode.md
@@ -68,7 +68,7 @@ Shorter, more cyclic paths reduce oozing and avoid dragging the nozzle over part
 
 > [!IMPORTANT]
 > NEW FEATURE: **Snake and Best of all (shortest path) intra-layer ordering**
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 - **Default**: Nearest-neighbour chaining, refined with 2-opt and crossing removal. A good general choice and the recommended option for most plates.
 - **As object list**: Instances are printed in the same order as the object list, without any path optimisation. Use it when you need a predictable, manually controlled order, for custom sequencing or debugging.

--- a/print_settings/speed/speed_settings_other_layers_speed.md
+++ b/print_settings/speed/speed_settings_other_layers_speed.md
@@ -146,7 +146,7 @@ Speed for the support interface layers, which are the layers directly contacting
 
 > [!IMPORTANT]
 > NEW FEATURE: **Small tree support perimeters** (speed and threshold)  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Same as [Small perimeters](#small-perimeters), but for supports.  
 This separate setting affects the speed of support for areas with a perimeter length <= [small tree support perimeters threshold](#small-tree-support-perimeters-threshold).  

--- a/print_settings/strength/strength_settings_infill.md
+++ b/print_settings/strength/strength_settings_infill.md
@@ -312,7 +312,7 @@ Specify exact layer numbers (1-based) using comma-separated values. Each entry m
 [CLI Example](cli_mode#setting-overrides): `--sparse-infill-smooth-factor=20%`.  
 > [!IMPORTANT]
 > NEW FEATURE: **Sparse infill smooth factor**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Rounds the corners of the sparse infill path, replacing each sharp direction change with a quintic Bézier curve that joins the two straight legs meeting at it.  
 `0%` keeps the original sharp path, while `100%` produces the largest possible curves between adjacent infill lines. A curve never consumes more than half of the shorter leg on each side of a corner, so the curves of two neighboring corners meet at most at the midpoint of the segment they share and never overlap.
@@ -373,7 +373,7 @@ Not every vertex of a supported pattern can be rounded, so some parts of the pat
 
 > [!IMPORTANT]
 > NEW FEATURE: **Top/Bottom layer direction**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Fixed angle (in degrees) for the top and bottom solid infill lines.  
 ![top-direction](https://github.com/OrcaSlicer/OrcaSlicer_WIKI/blob/main/images/directions/top-direction.png?raw=true)
@@ -390,7 +390,7 @@ Set to `-1` to follow the default solid infill [direction](#direction).
 
 > [!IMPORTANT]
 > NEW FEATURE: **Separated infills**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Centers the internal infill of each part on itself, as if it were sliced on its own, instead of on the whole assembly.  
 By default the entire assembly is treated as a single whole, so a centered or rotated infill pattern is referenced to one common center and rotates around it. When enabled, each part is centered on its own full 3D bounding box — producing the same pattern you would get by slicing that part on its own.

--- a/print_settings/strength/strength_settings_top_bottom_shells.md
+++ b/print_settings/strength/strength_settings_top_bottom_shells.md
@@ -90,7 +90,7 @@ If [Shell Layers](#shell-layers) is greater than 1, the surface pattern will be 
 
 > [!IMPORTANT]
 > NEW FEATURE: **Top surface expansion** (expansion, margin and direction)  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Expands the top surfaces by this distance (in mm) to connect distinct top surfaces and fill the gaps left where a feature rises through them.  
 This is useful when the top surface is interrupted by a raised feature, such as text or a boss on a plane, or when overlapping objects would otherwise split it: expanding the surface removes the holes beneath these features, keeps the top-surface pattern uninterrupted, and anchors the solid infill for a cleaner finish when printing on top. It also improves [concentric](strength_settings_patterns#concentric) top surfaces, whose pattern would otherwise be broken up by those small holes.  
@@ -162,7 +162,7 @@ When **Surface Expansion** is in use, those inner walls are removed over the top
 
 > [!IMPORTANT]
 > NEW FEATURE: **Center surface pattern on**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Chooses where the centering point of centered top/bottom surface patterns ([Archimedean Chords](strength_settings_patterns#archimedean-chords), [Octagram Spiral](strength_settings_patterns#octagram-spiral)) is placed.  
 By default these patterns are centered individually on each surface, which does not keep the pattern continuous across a whole product — a drawback for some artistic prints where the surfaces should read as one piece. This setting widens the scope of the shared center:
@@ -189,7 +189,7 @@ By default these patterns are centered individually on each surface, which does 
 
 > [!IMPORTANT]
 > NEW FEATURE: **Fill order**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Direction in which the top and bottom surfaces are filled when using a center-based pattern ([Concentric](strength_settings_patterns#concentric), [Archimedean Chords](strength_settings_patterns#archimedean-chords), [Octagram Spiral](strength_settings_patterns#octagram-spiral)). The spirals/rings are then deposited consistently inward or outward instead of following the default shortest path.
 

--- a/printer_settings/basic information/printer_basic_information_advanced.md
+++ b/printer_settings/basic information/printer_basic_information_advanced.md
@@ -42,7 +42,7 @@ What kind of G-code the printer is compatible with.
 [CLI Example](cli_mode#setting-overrides): `--gcode-skip-config-block=1`.  
 > [!IMPORTANT]
 > NEW FEATURE: **Skip G-code config block**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Removes the `CONFIG_BLOCK` (the commented-out block listing every resolved slicer setting) from the exported G-code file.
 

--- a/printer_settings/extruder/printer_extruder_retraction.md
+++ b/printer_settings/extruder/printer_extruder_retraction.md
@@ -103,7 +103,7 @@ This is the length of fast retraction before a wipe, relative to retraction leng
 
 > [!IMPORTANT]
 > NEW FEATURE: **Retract amount after wipe**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 This is the length of fast retraction after a wipe, relative to retraction length.  
 Together with [Retract amount before wipe](#retract-amount-before-wipe), this lets you split the retraction across the wipe: some before, some after, and the remainder performed during the wipe move itself. The value is clamped by 100% minus the retract amount before wipe, so the two combined never exceed the total retraction length.  

--- a/printer_settings/multimaterial/printer_multimaterial_wipe_tower.md
+++ b/printer_settings/multimaterial/printer_multimaterial_wipe_tower.md
@@ -43,7 +43,7 @@ Enable this option if you want the tool change to always be issued above the wip
 [CLI Example](cli_mode#setting-overrides): `--wait-for-temp-on-wipe-tower=1`.  
 > [!IMPORTANT]
 > NEW FEATURE: **Wait for temperature on wipe tower**  
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than **2.4.2**.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from **2.4.2**.
 
 Only relevant for multi-extruder (multi-toolhead) printers using a Type 2 wipe tower.  
 By default, the new tool's temperature wait happens immediately after the tool change command, wherever the toolhead is at that moment, which can leave ooze from the heat-up on top of the printed part.

--- a/publishing_3mf/publish_3mf.md
+++ b/publishing_3mf/publish_3mf.md
@@ -2,7 +2,7 @@
 
 > [!IMPORTANT]
 > NEW FEATURE: **Publish 3MF**
-> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases greater than 2.5.0.
+> Available in: [Nightly builds](https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/nightly-builds) or Releases starting from 2.5.0.
 
 **Publish 3MF** embeds the settings you choose into a 3MF file, so the model and its configuration are shared together.
 


### PR DESCRIPTION
# Description

"Releases greater than" sounds like its only available in the version number that came after it.

From a user's perspective, they just want to know from which version is a certain feature available. The correct logic should be "Releases greater than or equals to", but changing it to "Releases starting from" would make it easier to understand for readers.

@ianalexis Need a quick review on the features that were added previously to see if the version number coincides with the version that they were released in.